### PR TITLE
Improve interface and add aliases for 2026 apps

### DIFF
--- a/programas/cli-tools/configs/fastfetch.jsonc
+++ b/programas/cli-tools/configs/fastfetch.jsonc
@@ -1,42 +1,154 @@
 {
   "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
   "logo": {
-    "type": "small"
+    "type": "small",
+    "padding": {
+      "top": 1,
+      "left": 2
+    }
   },
   "display": {
+    "separator": " ➜  ",
     "color": {
       "keys": "magenta",
       "title": "cyan"
     }
   },
   "modules": [
-    "title",
+    "break",
+    {
+      "type": "title",
+      "format": "{user-name}@{host-name}"
+    },
     "separator",
-    "os",
-    "host",
-    "kernel",
-    "uptime",
-    "packages",
-    "shell",
-    "display",
-    "de",
-    "wm",
-    "wmtheme",
-    "theme",
-    "icons",
-    "font",
-    "cursor",
-    "terminal",
-    "terminalfont",
-    "cpu",
-    "gpu",
-    "memory",
-    "swap",
-    "disk",
-    "localip",
-    "battery",
-    "poweradapter",
-    "locale",
+    {
+      "type": "os",
+      "key": "OS   ",
+      "keyColor": "yellow"
+    },
+    {
+      "type": "host",
+      "key": "Host ",
+      "keyColor": "yellow"
+    },
+    {
+      "type": "kernel",
+      "key": "Krnl ",
+      "keyColor": "yellow"
+    },
+    {
+      "type": "uptime",
+      "key": "Up   ",
+      "keyColor": "yellow"
+    },
+    {
+      "type": "packages",
+      "key": "Pkgs ",
+      "keyColor": "yellow"
+    },
+    {
+      "type": "shell",
+      "key": "Sh   ",
+      "keyColor": "yellow"
+    },
+    "break",
+    {
+      "type": "display",
+      "key": "Disp ",
+      "keyColor": "green"
+    },
+    {
+      "type": "de",
+      "key": "DE   ",
+      "keyColor": "green"
+    },
+    {
+      "type": "wm",
+      "key": "WM   ",
+      "keyColor": "green"
+    },
+    {
+      "type": "wmtheme",
+      "key": "Theme",
+      "keyColor": "green"
+    },
+    {
+      "type": "theme",
+      "key": "GTK  ",
+      "keyColor": "green"
+    },
+    {
+      "type": "icons",
+      "key": "Icons",
+      "keyColor": "green"
+    },
+    {
+      "type": "font",
+      "key": "Font ",
+      "keyColor": "green"
+    },
+    {
+      "type": "cursor",
+      "key": "Curs ",
+      "keyColor": "green"
+    },
+    {
+      "type": "terminal",
+      "key": "Term ",
+      "keyColor": "green"
+    },
+    {
+      "type": "terminalfont",
+      "key": "TFont",
+      "keyColor": "green"
+    },
+    "break",
+    {
+      "type": "cpu",
+      "key": "CPU  ",
+      "keyColor": "cyan"
+    },
+    {
+      "type": "gpu",
+      "key": "GPU  ",
+      "keyColor": "cyan"
+    },
+    {
+      "type": "memory",
+      "key": "Mem  ",
+      "keyColor": "cyan"
+    },
+    {
+      "type": "swap",
+      "key": "Swap ",
+      "keyColor": "cyan"
+    },
+    {
+      "type": "disk",
+      "key": "Disk ",
+      "keyColor": "cyan"
+    },
+    "break",
+    {
+      "type": "localip",
+      "key": "LIP  ",
+      "keyColor": "blue"
+    },
+    {
+      "type": "battery",
+      "key": "Batt ",
+      "keyColor": "blue"
+    },
+    {
+      "type": "poweradapter",
+      "key": "Pwr  ",
+      "keyColor": "blue"
+    },
+    {
+      "type": "locale",
+      "key": "Loc  ",
+      "keyColor": "blue"
+    },
     "break",
     "colors"
   ]

--- a/programas/starship/starship.toml
+++ b/programas/starship/starship.toml
@@ -18,6 +18,19 @@ read_only = " 🔒"
 style = "bold #fede5d" # Neon Yellow
 symbol = " "
 
+[git_commit]
+style = "bold #ff7edb"
+commit_hash_length = 8
+tag_symbol = "🔖 "
+
+[git_state]
+style = "bold #ff7edb"
+
+[git_metrics]
+disabled = false
+added_style = "bold #72f1b8"
+deleted_style = "bold #ff5555"
+
 [git_status]
 style = "bold #ff7edb" # Neon Pink
 conflicted = "🏳"
@@ -91,6 +104,11 @@ style = "bold #36f9f6"
 [aws]
 symbol = "☁️  "
 style = "bold #fede5d"
+disabled = false
+
+[gcloud]
+symbol = "☁️  "
+style = "bold #36f9f6"
 disabled = false
 
 [kubernetes]

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -236,6 +236,12 @@ fi
 if command -v viddy &> /dev/null; then alias watch='viddy'; fi
 if command -v sesh &> /dev/null; then alias s='sesh connect'; fi
 
+# --- Interface Improvements 2026 ---
+if command -v amber &> /dev/null; then alias search='amber'; fi
+if command -v binsider &> /dev/null; then alias analyze='binsider'; fi
+if command -v serpl &> /dev/null; then alias sr='serpl'; fi
+if command -v tv &> /dev/null; then alias television='tv'; fi
+
 # --- End Custom Configuration ---
 EOT
 fi
@@ -305,6 +311,19 @@ if command -v zenith &> /dev/null; then alias top='zenith'; fi
 if command -v gobang &> /dev/null; then alias db='gobang'; fi
 if command -v tenki &> /dev/null; then alias weather='tenki'; fi
 if command -v tickrs &> /dev/null; then alias stocks='tickrs'; fi
+EOT
+fi
+
+# Check if Interface Improvements 2026 are present in .zshrc
+if ! grep -q "# --- Interface Improvements 2026 ---" "$ZSHRC"; then
+    echo -e "${c}Appending Interface Improvements 2026 to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Interface Improvements 2026 ---
+if command -v amber &> /dev/null; then alias search='amber'; fi
+if command -v binsider &> /dev/null; then alias analyze='binsider'; fi
+if command -v serpl &> /dev/null; then alias sr='serpl'; fi
+if command -v tv &> /dev/null; then alias television='tv'; fi
 EOT
 fi
 


### PR DESCRIPTION
This PR improves the terminal interface by updating the Fastfetch and Starship configurations to use a cohesive Synthwave '84 theme. It also adds Zsh aliases for several modern CLI tools (`amber`, `binsider`, `serpl`, `television`) that were installed but lacked convenient shortcuts. These changes aim to provide a more visually appealing and efficient "2026" development environment.

---
*PR created automatically by Jules for task [14065289913485555251](https://jules.google.com/task/14065289913485555251) started by @juninmd*