### PR TITLE
Add 2026 apps and improve terminal interface

### DIFF
--- a/programas/cli-tools/configs/fastfetch.jsonc
+++ b/programas/cli-tools/configs/fastfetch.jsonc
@@ -149,6 +149,16 @@
       "key": "Loc  ",
       "keyColor": "blue"
     },
+    {
+      "type": "datetime",
+      "key": "Time ",
+      "keyColor": "blue"
+    },
+    {
+      "type": "weather",
+      "key": "Weath",
+      "keyColor": "blue"
+    },
     "break",
     "colors"
   ]

--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -502,6 +502,51 @@ else
     echo -e "${c}dasel already installed.${r}"
 fi
 
+# --- ULTIMATE 2026 APPS ---
+
+# Just (Command Runner)
+install_cargo_crate just
+
+# Dive (Docker Image Explorer)
+if ! command -v dive &> /dev/null; then
+    echo -e "${c}Installing dive...${r}"
+    if command -v go &> /dev/null; then
+        go install github.com/wagoodman/dive@latest
+    else
+         echo -e "${c}Go not found, skipping dive installation.${r}"
+    fi
+else
+    echo -e "${c}dive already installed.${r}"
+fi
+
+# Fq (JQ for binary)
+install_cargo_crate fq
+
+# Htmlq (JQ for HTML)
+install_cargo_crate htmlq
+
+# Visidata (Terminal Spreadsheet)
+if ! command -v vd &> /dev/null; then
+    echo -e "${c}Installing visidata...${r}"
+    pip3 install visidata --break-system-packages 2>/dev/null || pip3 install visidata
+else
+    echo -e "${c}visidata already installed.${r}"
+fi
+
+# Trash-cli (Safer rm)
+if ! command -v trash &> /dev/null; then
+    echo -e "${c}Installing trash-cli...${r}"
+    pip3 install trash-cli --break-system-packages 2>/dev/null || pip3 install trash-cli
+else
+    echo -e "${c}trash-cli already installed.${r}"
+fi
+
+# Bacon (Background Rust Checker)
+install_cargo_crate bacon
+
+# Git-cliff (Changelog Generator)
+install_cargo_crate git-cliff
+
 # --- 2026 EYE CANDY & EXTRAS ---
 
 # Pokeget (Terminal Pokemon)

--- a/programas/starship/starship.toml
+++ b/programas/starship/starship.toml
@@ -3,6 +3,44 @@
 
 add_newline = true
 
+format = """
+$directory\
+$git_branch\
+$git_commit\
+$git_state\
+$git_metrics\
+$git_status\
+$nodejs\
+$python\
+$rust\
+$golang\
+$crystal\
+$scala\
+$kotlin\
+$zig\
+$lua\
+$dart\
+$julia\
+$cmake\
+$gradle\
+$maven\
+$docker_context\
+$aws\
+$gcloud\
+$kubernetes\
+$os\
+$container\
+$fill\
+$cmd_duration\
+$memory_usage\
+$battery\
+$time\
+$line_break\
+$character"""
+
+[fill]
+symbol = " "
+
 [character]
 success_symbol = '[➜](bold #36f9f6)' # Neon Cyan
 error_symbol = '[✗](bold #ff7edb)'   # Neon Pink

--- a/programas/zellij/config.kdl
+++ b/programas/zellij/config.kdl
@@ -48,5 +48,6 @@ keybinds {
 ui {
     pane_frames {
         hide_session_name true
+        rounded_corners true
     }
 }


### PR DESCRIPTION
This PR updates the CLI tools setup to include a curated list of modern "2026" applications, focusing on Rust and Go-based utilities. It also enhances the user interface by modernizing the Starship prompt with a right-aligned status bar, enabling rounded corners in Zellij, and adding time/weather information to Fastfetch. The changes align with the existing Synthwave '84 theme.

---
*PR created automatically by Jules for task [1474109698094900547](https://jules.google.com/task/1474109698094900547) started by @juninmd*