### PR TITLE
Add 2026 apps and improve fastfetch interface

### DIFF
--- a/programas/cli-tools/configs/fastfetch.jsonc
+++ b/programas/cli-tools/configs/fastfetch.jsonc
@@ -182,6 +182,26 @@
       "key": "Media",
       "keyColor": "blue"
     },
+    {
+      "type": "netio",
+      "key": "NetIO",
+      "keyColor": "blue"
+    },
+    {
+      "type": "diskio",
+      "key": "DskIO",
+      "keyColor": "blue"
+    },
+    {
+      "type": "bluetooth",
+      "key": "BlueT",
+      "keyColor": "blue"
+    },
+    {
+      "type": "sound",
+      "key": "Sound",
+      "keyColor": "blue"
+    },
     "break",
     "colors"
   ]

--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -684,6 +684,23 @@ install_cargo_crate dua-cli dua
 # Mprocs (Process Manager)
 install_cargo_crate mprocs
 
+# --- 2026 APPS PART III ---
+
+# Topgrade (Upgrade Everything)
+install_cargo_crate topgrade
+
+# Hexyl (Command-line Hex Viewer)
+install_cargo_crate hexyl
+
+# Pastel (Command-line Color Tool)
+install_cargo_crate pastel
+
+# Csvlens (CSV File Viewer)
+install_cargo_crate csvlens
+
+# Qsv (High-performance CSV Data-Wrangling Toolkit)
+install_cargo_crate qsv
+
 # Configure Bat Theme
 echo -e "${c}Configuring Bat Theme...${r}"
 BAT_CONFIG_DIR="$(bat --config-dir)"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -384,6 +384,19 @@ if command -v mprocs &> /dev/null; then alias run='mprocs'; fi
 EOT
 fi
 
+# Check if 2026 Apps Part III are present in .zshrc
+if ! grep -q "# --- 2026 Apps Part III ---" "$ZSHRC"; then
+    echo -e "${c}Appending 2026 Apps Part III to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- 2026 Apps Part III ---
+if command -v topgrade &> /dev/null; then alias update='topgrade'; fi
+if command -v hexyl &> /dev/null; then alias hex='hexyl'; fi
+if command -v pastel &> /dev/null; then alias color='pastel'; fi
+if command -v csvlens &> /dev/null; then alias csv='csvlens'; fi
+EOT
+fi
+
 # Update zoxide to use cd alias if present in existing config
 sed -i 's/eval "$(zoxide init zsh)"/eval "$(zoxide init zsh --cmd cd)"/' "$ZSHRC"
 


### PR DESCRIPTION
Improved the interface by adding more detailed system information to Fastfetch (NetIO, DiskIO, Bluetooth, Sound) and added a set of useful 2026 apps (`topgrade`, `hexyl`, `pastel`, `csvlens`, `qsv`) with convenient shell aliases.

---
*PR created automatically by Jules for task [10234004299769144760](https://jules.google.com/task/10234004299769144760) started by @juninmd*