### PR TITLE
feat: improve setup interface and add more modern 2026 apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -593,6 +593,27 @@ install_cargo_crate amber
 
 # --- NEWEST 2026 APPS ---
 
+# GH (GitHub CLI)
+install_go_package github.com/cli/cli/v2/cmd/gh@latest gh
+
+# Act (Run GitHub Actions Locally)
+install_go_package github.com/nektos/act@latest act
+
+# Ast-grep (AST-based search and replace)
+install_cargo_crate ast-grep sg
+
+# Sad (CLI search and replace)
+install_cargo_crate sad
+
+# Jaq (JQ clone in Rust)
+install_cargo_crate jaq
+
+# Jnv (Interactive JQ filter)
+install_cargo_crate jnv
+
+# Watchexec (Execute commands in response to file modifications)
+install_cargo_crate watchexec-cli watchexec
+
 # Mcfly (Neural Network Shell History)
 install_cargo_crate mcfly
 


### PR DESCRIPTION
Improves the interface of the `setup-2026.sh` script to be more modern and interactive using `gum`. If `gum` is missing, it creates a secure temporary directory and downloads a temporary binary via `wget` and `tar`, before deleting it upon script completion. Additionally, several more modern "2026" cli applications (`gh`, `act`, `ast-grep`, `sad`, `jaq`, `jnv`, `watchexec`) were added to the `cli-tools` setup script.

---
*PR created automatically by Jules for task [7946044959198493954](https://jules.google.com/task/7946044959198493954) started by @juninmd*