### PR TITLE
Improve setup UI and add new 2026 CLI apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -705,6 +705,17 @@ install_cargo_crate dua-cli dua
 # Mprocs (Process Manager)
 install_cargo_crate mprocs
 
+# --- EXTRA 2026 APPS ---
+
+# Kdash (Kubernetes Dashboard)
+install_cargo_crate kdash
+
+# Stern (Multi pod logs)
+install_go_package github.com/stern/stern@latest stern
+
+# Fabric (AI CLI framework)
+install_go_package github.com/danielmiessler/fabric@latest fabric
+
 # --- 2026 APPS PART III ---
 
 # Topgrade (Upgrade Everything)

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -249,6 +249,11 @@ fi
 if command -v nu &> /dev/null; then alias nu='nu'; fi
 if command -v btm &> /dev/null; then alias btm='btm'; fi
 
+# --- Extra 2026 Apps ---
+if command -v kdash &> /dev/null; then alias kdash='kdash'; fi
+if command -v stern &> /dev/null; then alias stern='stern'; fi
+if command -v fabric &> /dev/null; then alias ai='fabric'; fi
+
 # --- End Custom Configuration ---
 EOT
 fi
@@ -394,6 +399,18 @@ if command -v topgrade &> /dev/null; then alias update='topgrade'; fi
 if command -v hexyl &> /dev/null; then alias hex='hexyl'; fi
 if command -v pastel &> /dev/null; then alias color='pastel'; fi
 if command -v csvlens &> /dev/null; then alias csv='csvlens'; fi
+EOT
+fi
+
+# Check if Extra 2026 Apps are present in .zshrc
+if ! grep -q "# --- Extra 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Extra 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Extra 2026 Apps ---
+if command -v kdash &> /dev/null; then alias kdash='kdash'; fi
+if command -v stern &> /dev/null; then alias stern='stern'; fi
+if command -v fabric &> /dev/null; then alias ai='fabric'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -24,7 +24,7 @@ log() {
   if command -v "$GUM" &> /dev/null; then
     "$GUM" style --foreground 212 "[$($GUM style --foreground 250 "2026-setup")] $*"
   else
-    printf '[2026-setup] %s\n' "$*"
+    printf '\e[36m[2026-setup]\e[0m %s\n' "$*"
   fi
 }
 


### PR DESCRIPTION
This PR improves the fallback logging UI in the main `setup-2026.sh` script by utilizing ANSI escape sequences (cyan) so that logs look distinct even if the `gum` UI library is unavailable.

Additionally, it adds three highly useful modern CLI tools for 2026:
- `kdash`: A fast Kubernetes dashboard.
- `stern`: A tool for viewing logs from multiple pods simultaneously.
- `fabric`: An AI CLI framework.

Aliases for these new tools have also been added to the `.zshrc` setup (`kdash`, `stern`, `ai` respectively). All scripts have been checked for syntax errors.

---
*PR created automatically by Jules for task [15901029179031080777](https://jules.google.com/task/15901029179031080777) started by @juninmd*