### PR TITLE
Improve Interface and Add 2026 Apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -806,6 +806,24 @@ install_cargo_crate macchina
 # JQL (JSON Query Language CLI)
 install_cargo_crate jql
 
+# Pomsky (Portable modern regular expression language)
+install_cargo_crate pomsky-bin pomsky
+
+# Fend (Arbitrary-precision unit-aware calculator)
+install_cargo_crate fend
+
+# Xc (Markdown defined task runner)
+install_go_package github.com/joerdav/xc/cmd/xc@latest xc
+
+# Gtt (Google Translate TUI)
+install_go_package github.com/eeeXun/gtt@latest gtt
+
+# Go-task (Modern Make alternative)
+install_go_package github.com/go-task/task/v3/cmd/task@latest task
+
+# Sops (Secrets Management) - explicitly add if missing
+install_go_package github.com/getsops/sops/v3/cmd/sops@latest sops
+
 # Configure Bat Theme
 echo -e "${c}Configuring Bat Theme...${r}"
 BAT_CONFIG_DIR="$(bat --config-dir)"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -262,6 +262,13 @@ if command -v typos &> /dev/null; then alias spellcheck='typos'; fi
 if command -v cog &> /dev/null; then alias commit='cog commit'; fi
 if command -v gron &> /dev/null; then alias unjson='gron'; fi
 
+# --- 2026 Extra CLI Apps ---
+if command -v pomsky &> /dev/null; then alias regex-gen='pomsky'; fi
+if command -v fend &> /dev/null; then alias calc='fend'; fi
+if command -v xc &> /dev/null; then alias tasks-md='xc'; fi
+if command -v gtt &> /dev/null; then alias translate='gtt'; fi
+if command -v task &> /dev/null; then alias t='task'; fi
+
 # --- End Custom Configuration ---
 EOT
 fi
@@ -376,7 +383,7 @@ if command -v cointop &> /dev/null; then alias crypto='cointop'; fi
 if command -v wtf &> /dev/null; then alias dashboard='wtf'; fi
 if command -v taskwarrior-tui &> /dev/null; then alias tasks='taskwarrior-tui'; fi
 if command -v nap &> /dev/null; then alias snippets='nap'; fi
-if command -v kondo &> /dev/null; then alias clean-system='kondo'; fi
+if command -v kondo &> /dev/null; then alias clean='kondo'; fi
 EOT
 fi
 
@@ -434,6 +441,20 @@ if command -v macchina &> /dev/null; then alias sysinfo='macchina'; fi
 if command -v typos &> /dev/null; then alias spellcheck='typos'; fi
 if command -v cog &> /dev/null; then alias commit='cog commit'; fi
 if command -v gron &> /dev/null; then alias unjson='gron'; fi
+EOT
+fi
+
+# Check if 2026 Extra CLI Apps are present in .zshrc
+if ! grep -q "# --- 2026 Extra CLI Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending 2026 Extra CLI Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- 2026 Extra CLI Apps ---
+if command -v pomsky &> /dev/null; then alias regex-gen='pomsky'; fi
+if command -v fend &> /dev/null; then alias calc='fend'; fi
+if command -v xc &> /dev/null; then alias tasks-md='xc'; fi
+if command -v gtt &> /dev/null; then alias translate='gtt'; fi
+if command -v task &> /dev/null; then alias t='task'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -60,7 +60,15 @@ run_module() {
     chmod +x "$script"
   fi
 
-  run_step "Executando módulo: $module" "$script"
+  if [[ "$DRY_RUN" == true ]]; then
+    run_step "Executando módulo: $module" "$script"
+  else
+    if command -v "$GUM" &> /dev/null; then
+      "$GUM" spin --spinner dot --title "Executando módulo: $module..." -- bash -c "$script > /tmp/setup-2026-$module.log 2>&1"
+    else
+      run_step "Executando módulo: $module" "$script"
+    fi
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -134,6 +142,12 @@ if [[ "$DRY_RUN" == false ]]; then
       exit 0
     fi
   fi
+fi
+
+if [[ "$DRY_RUN" == false ]] && command -v sudo &> /dev/null; then
+  sudo -v
+  # Keep-alive: update existing sudo time stamp until script has finished
+  while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 fi
 
 for module in "${MODULES[@]}"; do

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -64,7 +64,7 @@ run_module() {
     run_step "Executando módulo: $module" "$script"
   else
     if command -v "$GUM" &> /dev/null; then
-      "$GUM" spin --spinner dot --title "Executando módulo: $module..." -- bash -c "$script > /tmp/setup-2026-$module.log 2>&1"
+      "$GUM" spin --spinner dot --title "Executando módulo: $module..." -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"
     else
       run_step "Executando módulo: $module" "$script"
     fi


### PR DESCRIPTION
This change improves the visual aesthetics and reliability of the `setup-2026.sh` script by utilizing `gum spin` to hide long terminal outputs behind a clean animated spinner. Additionally, a `sudo` keepalive loop was added to prevent mid-installation password prompts.

Furthermore, several cutting-edge CLI tools (`pomsky`, `fend`, `xc`, `gtt`, `task`) have been integrated into `cli-tools` and automatically aliased into the Zsh environment.

---
*PR created automatically by Jules for task [12588468518963448623](https://jules.google.com/task/12588468518963448623) started by @juninmd*