### PR TITLE
feat: improve installation UI and add new 2026 CLI tools

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -635,6 +635,15 @@ else
     echo -e "${c}eget already installed.${r}"
 fi
 
+# Tailspin (Log Highlighter)
+install_cargo_crate tailspin tspin
+
+# Slumber (Terminal HTTP Client)
+install_cargo_crate slumber
+
+# JQP (TUI for jq)
+install_go_package github.com/noahgorstein/jqp@latest jqp
+
 # --- THE FUTURE IS NOW (New 2026 Apps) ---
 
 # Deno (Modern JS/TS Runtime)

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -248,6 +248,9 @@ if command -v mcfly &> /dev/null; then
 fi
 if command -v nu &> /dev/null; then alias nu='nu'; fi
 if command -v btm &> /dev/null; then alias btm='btm'; fi
+if command -v tspin &> /dev/null; then alias logs='tspin'; fi
+if command -v slumber &> /dev/null; then alias http-ui='slumber'; fi
+if command -v jqp &> /dev/null; then alias jq-ui='jqp'; fi
 
 # --- Extra 2026 Apps ---
 if command -v kdash &> /dev/null; then alias kdash='kdash'; fi
@@ -376,6 +379,9 @@ if command -v mcfly &> /dev/null; then
 fi
 if command -v nu &> /dev/null; then alias nu='nu'; fi
 if command -v btm &> /dev/null; then alias btm='btm'; fi
+if command -v tspin &> /dev/null; then alias logs='tspin'; fi
+if command -v slumber &> /dev/null; then alias http-ui='slumber'; fi
+if command -v jqp &> /dev/null; then alias jq-ui='jqp'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -64,7 +64,7 @@ run_module() {
     run_step "Executando módulo: $module" "$script"
   else
     if command -v "$GUM" &> /dev/null; then
-      "$GUM" spin --spinner dot --title "Executando módulo: $module..." -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"
+      "$GUM" spin --spinner dot --title "$($GUM style --foreground "#72f1b8" "Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"
     else
       run_step "Executando módulo: $module" "$script"
     fi
@@ -101,8 +101,16 @@ if [[ -z "$PROFILE" ]]; then
       --align center --width 60 --margin "1 2" --padding "2 4" \
       '⚡ DOTFILES 2026 EDITION ⚡' 'O Futuro do Desenvolvimento'
 
-    echo "🚀 Escolha o perfil de instalação para turbinar sua máquina:"
+    echo ""
+    "$GUM" style --foreground "#36f9f6" "🚀 Escolha o perfil de instalação para turbinar sua máquina:"
+    echo ""
     PROFILE_CHOICE=$("$GUM" choose \
+      --cursor="👉 " \
+      --header="Selecione um perfil abaixo:" \
+      --header.foreground="#ff7edb" \
+      --cursor.foreground="#36f9f6" \
+      --item.foreground="#f8f8f2" \
+      --selected.foreground="#72f1b8" \
       "minimal   - Shell moderna, prompt limpo e editor básico." \
       "dev       - minimal + Runtimes JS/Python, Docker e Banco de Dados (Recomendado)." \
       "full      - dev + Apps extras de produtividade (Navegador, Slack, etc).")
@@ -136,7 +144,7 @@ if command -v "$GUM" &> /dev/null; then
   echo ""
   "$GUM" style --foreground "#72f1b8" --bold "📦 Módulos que serão instalados:"
   for mod in "${MODULES[@]}"; do
-    echo "  • $mod"
+    echo "  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod")"
   done
   echo ""
 else
@@ -145,10 +153,12 @@ fi
 
 if [[ "$DRY_RUN" == false ]]; then
   if command -v "$GUM" &> /dev/null; then
-    if ! "$GUM" confirm "Deseja prosseguir com a instalação destes módulos e transformar seu setup?"; then
+    echo ""
+    if ! "$GUM" confirm --unselected.background "" --unselected.foreground "#f8f8f2" --selected.background "#bd93f9" --selected.foreground "#282a36" "Deseja prosseguir com a instalação destes módulos e transformar seu setup?"; then
       log "Instalação cancelada pelo usuário."
       exit 0
     fi
+    echo ""
   else
     read -rp "Deseja prosseguir com a instalação destes módulos? (S/n): " confirm
     if [[ "$confirm" =~ ^[Nn] ]]; then


### PR DESCRIPTION
This PR addresses the user request to improve the UI of the installation interface and add new, useful "2026 apps". 

1. **Interface Improvement:** I modified `setup-2026.sh` to leverage `gum` with full Synthwave color styling. The profile selection now features a styled cursor (`👉 `), colored headers, and specifically styled selected/unselected text. I also updated the module listing display to look more polished and the background spinner to match the theme.
2. **2026 Apps Addition:** I incorporated three modern, highly-rated Rust and Go CLI tools to `programas/cli-tools/setup.sh` that were missing:
    - **Tailspin (`tspin`)**: A powerful, fast log file highlighter.
    - **Slumber (`slumber`)**: A modern terminal HTTP client.
    - **JQP (`jqp`)**: A TUI specifically for exploring and querying JSON with `jq`.
3. **Aliases:** Added corresponding aliases to `programas/zsh/setup.sh` so these tools are immediately accessible (`logs` -> `tspin`, `http-ui` -> `slumber`, `jq-ui` -> `jqp`).

---
*PR created automatically by Jules for task [13210623585532509068](https://jules.google.com/task/13210623585532509068) started by @juninmd*