### PR TITLE
feat: Improve setup interface and add 2026 AI tools

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -835,6 +835,37 @@ install_go_package github.com/getsops/sops/v3/cmd/sops@latest sops
 
 # --- 2026 CUTTING EDGE APPS ---
 
+# Harlequin (SQL IDE for terminal)
+if ! command -v harlequin &> /dev/null; then
+    echo -e "${c}Installing harlequin...${r}"
+    pip3 install harlequin --break-system-packages 2>/dev/null || pip3 install harlequin
+else
+    echo -e "${c}harlequin already installed.${r}"
+fi
+
+# Gitingest (Replace git clone with AI friendly prompt)
+if ! command -v gitingest &> /dev/null; then
+    echo -e "${c}Installing gitingest...${r}"
+    pip3 install gitingest --break-system-packages 2>/dev/null || pip3 install gitingest
+else
+    echo -e "${c}gitingest already installed.${r}"
+fi
+
+# Repomix (Pack repository into AI prompt)
+if ! command -v repomix &> /dev/null; then
+    echo -e "${c}Installing repomix...${r}"
+    if command -v npm &> /dev/null; then
+        sudo npm install -g repomix
+    else
+        echo -e "${c}npm not found, skipping repomix installation.${r}"
+    fi
+else
+    echo -e "${c}repomix already installed.${r}"
+fi
+
+# Tenv (OpenTofu/Terraform version manager)
+install_go_package github.com/tofuutils/tenv/v3@latest tenv
+
 # Plandex (AI coding engine)
 if ! command -v plandex &> /dev/null; then
     echo -e "${c}Installing plandex...${r}"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -283,6 +283,12 @@ if command -v chafa &> /dev/null; then alias img='chafa'; fi
 if command -v lsd &> /dev/null; then alias ls2='lsd'; fi
 if command -v dprint &> /dev/null; then alias fmt='dprint'; fi
 
+# --- 2026 AI Apps ---
+if command -v harlequin &> /dev/null; then alias sql-ide='harlequin'; fi
+if command -v gitingest &> /dev/null; then alias ingest='gitingest'; fi
+if command -v repomix &> /dev/null; then alias repo-pack='repomix'; fi
+if command -v tenv &> /dev/null; then alias tf-env='tenv'; fi
+
 # --- End Custom Configuration ---
 EOT
 fi
@@ -490,6 +496,19 @@ if command -v kubecolor &> /dev/null; then alias kubectl='kubecolor'; fi
 if command -v chafa &> /dev/null; then alias img='chafa'; fi
 if command -v lsd &> /dev/null; then alias ls2='lsd'; fi
 if command -v dprint &> /dev/null; then alias fmt='dprint'; fi
+EOT
+fi
+
+# Check if 2026 AI Apps are present in .zshrc
+if ! grep -q "# --- 2026 AI Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending 2026 AI Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- 2026 AI Apps ---
+if command -v harlequin &> /dev/null; then alias sql-ide='harlequin'; fi
+if command -v gitingest &> /dev/null; then alias ingest='gitingest'; fi
+if command -v repomix &> /dev/null; then alias repo-pack='repomix'; fi
+if command -v tenv &> /dev/null; then alias tf-env='tenv'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -123,13 +123,13 @@ fi
 
 case "$PROFILE" in
   minimal)
-    MODULES=(cli-tools zsh starship vscode)
+    DEFAULT_MODULES=(cli-tools zsh starship vscode)
     ;;
   dev)
-    MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi)
+    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi)
     ;;
   full)
-    MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi firefox slack)
+    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi firefox slack)
     ;;
   *)
     log "Perfil inválido: $PROFILE"
@@ -140,15 +140,51 @@ esac
 
 log "Perfil selecionado: $PROFILE"
 
+# Get all available modules
+ALL_MODULES=()
+for dir in "$ROOT_DIR"/programas/*/; do
+  mod=$(basename "$dir")
+  # Exclude 'common' or other non-installable modules if necessary
+  if [[ "$mod" != "common" && -f "$dir/setup.sh" ]]; then
+    ALL_MODULES+=("$mod")
+  fi
+done
+
 if command -v "$GUM" &> /dev/null; then
+  echo ""
+  "$GUM" style --foreground "#36f9f6" "Selecione os módulos que deseja instalar (Espaço para marcar/desmarcar, Enter para confirmar):"
+  echo ""
+
+  # Prepare comma-separated default modules string
+  DEFAULTS=$(IFS=,; echo "${DEFAULT_MODULES[*]}")
+
+  # Interactive selection
+  SELECTED_MODULES=$("$GUM" choose --no-limit --cursor="👉 " \
+    --selected="${DEFAULTS}" \
+    --selected.foreground="#72f1b8" \
+    --cursor.foreground="#36f9f6" \
+    "${ALL_MODULES[@]}")
+
+  # Convert newline-separated string back to array
+  mapfile -t MODULES <<< "$SELECTED_MODULES"
+
   echo ""
   "$GUM" style --foreground "#72f1b8" --bold "📦 Módulos que serão instalados:"
   for mod in "${MODULES[@]}"; do
-    echo "  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod")"
+    if [ -n "$mod" ]; then
+      echo "  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod")"
+    fi
   done
   echo ""
 else
-  log "Módulos: ${MODULES[*]}"
+  MODULES=("${DEFAULT_MODULES[@]}")
+  log "Módulos padrão: ${MODULES[*]}"
+fi
+
+# Ensure MODULES is not empty
+if [ ${#MODULES[@]} -eq 0 ] || [ -z "${MODULES[0]}" ]; then
+  log "Nenhum módulo selecionado. Saindo..."
+  exit 0
 fi
 
 if [[ "$DRY_RUN" == false ]]; then


### PR DESCRIPTION
Improves the interactive setup experience and includes a few new cutting-edge 2026 development tools.

- The `setup-2026.sh` script now finds available modules in the `programas/` folder and allows the user to individually select or unselect exactly what they want to install, improving flexibility. The default selection is populated based on the chosen profile (`minimal`, `dev`, `full`).
- Includes new app installations:
  - `harlequin`: Terminal SQL IDE.
  - `gitingest`: Generates AI-friendly prompts from git repositories.
  - `repomix`: Packs repositories into an AI context.
  - `tenv`: Version manager for Terraform and OpenTofu.
- Modifies `.zshrc` to include handy aliases for these new tools.

---
*PR created automatically by Jules for task [12228946469428866134](https://jules.google.com/task/12228946469428866134) started by @juninmd*