### PR TITLE
Improve interactive setup interface and add new 2026 CLI apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -835,6 +835,18 @@ install_go_package github.com/getsops/sops/v3/cmd/sops@latest sops
 
 # --- 2026 CUTTING EDGE APPS ---
 
+# Numbat (High precision scientific calculator)
+install_cargo_crate numbat-cli numbat
+
+# Scc (Sloc, Cloc and Code - Fast accurate code counter)
+install_go_package github.com/boyter/scc/v3@latest scc
+
+# Gping (Ping, but with a graph)
+install_cargo_crate gping
+
+# Doggo (Command-line DNS Client)
+install_go_package github.com/mr-karan/doggo/cmd/doggo@latest doggo
+
 # Harlequin (SQL IDE for terminal)
 if ! command -v harlequin &> /dev/null; then
     echo -e "${c}Installing harlequin...${r}"

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -140,6 +140,23 @@ esac
 
 log "Perfil selecionado: $PROFILE"
 
+# Human-readable descriptions for the modules
+declare -A MOD_DESC=(
+  ["android"]="Android Studio & SDK"
+  ["bun"]="Bun JavaScript runtime"
+  ["cli-tools"]="Ferramentas CLI modernas (2026 apps)"
+  ["firefox"]="Navegador Firefox"
+  ["lazydocker"]="LazyDocker TUI"
+  ["lazygit"]="LazyGit TUI"
+  ["mysql"]="MySQL Server & Client"
+  ["slack"]="Slack Desktop"
+  ["starship"]="Starship Prompt"
+  ["vscode"]="Visual Studio Code"
+  ["yazi"]="Yazi File Manager"
+  ["zellij"]="Zellij Terminal Multiplexer"
+  ["zsh"]="Zsh shell e plugins"
+)
+
 # Get all available modules
 ALL_MODULES=()
 for dir in "$ROOT_DIR"/programas/*/; do
@@ -155,24 +172,43 @@ if command -v "$GUM" &> /dev/null; then
   "$GUM" style --foreground "#36f9f6" "Selecione os módulos que deseja instalar (Espaço para marcar/desmarcar, Enter para confirmar):"
   echo ""
 
-  # Prepare comma-separated default modules string
-  DEFAULTS=$(IFS=,; echo "${DEFAULT_MODULES[*]}")
+  # Prepare choices with descriptions
+  CHOICES=()
+  for mod in "${ALL_MODULES[@]}"; do
+    desc="${MOD_DESC[$mod]:-Módulo $mod}"
+    CHOICES+=("$mod - $desc")
+  done
+
+  # Prepare comma-separated default modules string with descriptions
+  DEFAULTS_DESC=()
+  for mod in "${DEFAULT_MODULES[@]}"; do
+    desc="${MOD_DESC[$mod]:-Módulo $mod}"
+    DEFAULTS_DESC+=("$mod - $desc")
+  done
+  DEFAULTS=$(IFS=,; echo "${DEFAULTS_DESC[*]}")
 
   # Interactive selection
-  SELECTED_MODULES=$("$GUM" choose --no-limit --cursor="👉 " \
+  SELECTED_TEXT=$("$GUM" choose --no-limit --cursor="👉 " \
     --selected="${DEFAULTS}" \
     --selected.foreground="#72f1b8" \
     --cursor.foreground="#36f9f6" \
-    "${ALL_MODULES[@]}")
+    "${CHOICES[@]}")
 
-  # Convert newline-separated string back to array
-  mapfile -t MODULES <<< "$SELECTED_MODULES"
+  # Extract module directories from the selected text
+  MODULES=()
+  while IFS= read -r line; do
+    if [ -n "$line" ]; then
+      mod=$(echo "$line" | awk '{print $1}')
+      MODULES+=("$mod")
+    fi
+  done <<< "$SELECTED_TEXT"
 
   echo ""
   "$GUM" style --foreground "#72f1b8" --bold "📦 Módulos que serão instalados:"
   for mod in "${MODULES[@]}"; do
     if [ -n "$mod" ]; then
-      echo "  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod")"
+      desc="${MOD_DESC[$mod]:-Módulo $mod}"
+      echo "  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod") $($GUM style --foreground "#6272a4" "($desc)")"
     fi
   done
   echo ""

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -198,7 +198,7 @@ if command -v "$GUM" &> /dev/null; then
   MODULES=()
   while IFS= read -r line; do
     if [ -n "$line" ]; then
-      mod=$(echo "$line" | awk '{print $1}')
+      mod="${line%% *}"
       MODULES+=("$mod")
     fi
   done <<< "$SELECTED_TEXT"


### PR DESCRIPTION
1. Improved `setup-2026.sh` interactive TUI.
2. Added `declare -A MOD_DESC` to map `programas/` directories to friendly strings.
3. Updated the parser loop.
4. Added Numbat, Scc, Gping, and Doggo to `programas/cli-tools/setup.sh` to introduce more cutting edge modern CLI utilities.

---
*PR created automatically by Jules for task [10761926015839336311](https://jules.google.com/task/10761926015839336311) started by @juninmd*