### PR TITLE
feat: enhance setup script banner and add new modern CLI tools

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1118,4 +1118,26 @@ else
     echo -e "${c}Warning: synthwave.theme not found in $SCRIPT_DIR/themes/btop${r}"
 fi
 
+# --- NEW 2026 APPS ---
+
+# Ctop (Top-like interface for container metrics)
+install_go_package github.com/bcicen/ctop@latest ctop
+
+# Httpie (Modern, user-friendly command-line HTTP client)
+if ! command -v http &> /dev/null; then
+    echo -e "${c}Installing httpie...${r}"
+    pip3 install httpie --break-system-packages 2>/dev/null || pip3 install httpie
+else
+    echo -e "${c}httpie already installed.${r}"
+fi
+
+# Croc (Easily and securely send things from one computer to another)
+install_go_package github.com/schollz/croc/v10@latest croc
+
+# Dufs (A distinctive utility file server)
+install_cargo_crate dufs
+
+# Cheat (Create and view interactive cheatsheets on the command-line)
+install_go_package github.com/cheat/cheat/cmd/cheat@latest cheat
+
 echo -e "${c}CLI Tools installed! Ensure ~/.local/bin, ~/.cargo/bin and ~/go/bin are in your PATH.${r}"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -312,6 +312,13 @@ if command -v broot &> /dev/null; then alias br='broot'; fi
 if command -v pueue &> /dev/null; then alias pq='pueue'; fi
 if command -v hyperfine &> /dev/null; then alias hf='hyperfine'; fi
 
+# --- New 2026 Apps ---
+if command -v ctop &> /dev/null; then alias docker-top='ctop'; fi
+if command -v http &> /dev/null; then alias http='http'; fi
+if command -v croc &> /dev/null; then alias send='croc'; fi
+if command -v dufs &> /dev/null; then alias share='dufs'; fi
+if command -v cheat &> /dev/null; then alias cheatsheet='cheat'; fi
+
 # --- End Custom Configuration ---
 EOT
 fi
@@ -575,6 +582,20 @@ if command -v trip &> /dev/null; then alias traceroute='trip'; fi
 if command -v broot &> /dev/null; then alias br='broot'; fi
 if command -v pueue &> /dev/null; then alias pq='pueue'; fi
 if command -v hyperfine &> /dev/null; then alias hf='hyperfine'; fi
+EOT
+fi
+
+# Check if New 2026 Apps are present in .zshrc
+if ! grep -q "# --- New 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending New 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- New 2026 Apps ---
+if command -v ctop &> /dev/null; then alias docker-top='ctop'; fi
+if command -v http &> /dev/null; then alias http='http'; fi
+if command -v croc &> /dev/null; then alias send='croc'; fi
+if command -v dufs &> /dev/null; then alias share='dufs'; fi
+if command -v cheat &> /dev/null; then alias cheatsheet='cheat'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -111,7 +111,8 @@ if [[ -z "$PROFILE" ]]; then
       ' / /_| |_| / /| (_) |' \
       '|____|\___/____\___/ ' \
       '' \
-      '⚡ DOTFILES 2026 EDITION ⚡' 'O Futuro do Desenvolvimento'
+      '⚡ DOTFILES 2026 EDITION ⚡' 'O Futuro do Desenvolvimento' \
+      '👾 THE SYNTHWAVE EXPERIENCE 👾'
 
     echo ""
     "$GUM" style --foreground "#36f9f6" --border normal --border-foreground "#36f9f6" --padding "1 2" --margin "1 0" "🚀 Escolha o perfil de instalação para turbinar sua máquina:"


### PR DESCRIPTION
This commit addresses the issue of improving the interface of the setup script and adding more useful 2026 applications.

Changes made:
- Updated `setup-2026.sh` to include a cool new "THE SYNTHWAVE EXPERIENCE" aesthetic line on the start menu banner.
- Updated `programas/cli-tools/setup.sh` to install 5 additional CLI apps: `ctop` (go), `httpie` (pip), `croc` (go), `dufs` (cargo), and `cheat` (go).
- Updated `programas/zsh/setup.sh` to map user-friendly aliases for these commands: `docker-top`, `http`, `send`, `share`, and `cheatsheet` respectively, configuring it to automatically append these missing properties for subsequent loads or existing `.zshrc` configurations.

---
*PR created automatically by Jules for task [4834258310980472212](https://jules.google.com/task/4834258310980472212) started by @juninmd*