### PR TITLE
Enhance setup interface and add new 2026 CLI tools

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1039,6 +1039,50 @@ else
     echo -e "${c}devbox already installed.${r}"
 fi
 
+# --- CHARMBRACELET EXTRAS ---
+
+# Skate (Personal Key Value Store)
+install_go_package github.com/charmbracelet/skate@latest skate
+
+# Melt (SSH key backup and restore)
+install_go_package github.com/charmbracelet/melt@latest melt
+
+# --- KUBERNETES EXTRAS ---
+
+# Krew (Kubectl plugin manager)
+if ! command -v kubectl-krew &> /dev/null; then
+    echo -e "${c}Installing Krew...${r}"
+    (
+      set -x; cd "$(mktemp -d)" &&
+      OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+      ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+      KREW="krew-${OS}_${ARCH}" &&
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+      tar zxvf "${KREW}.tar.gz" &&
+      ./"${KREW}" install krew
+    )
+else
+    echo -e "${c}Krew already installed.${r}"
+fi
+
+# Kubectx and Kubens (Kubernetes context switching)
+install_go_package github.com/ahmetb/kubectx/cmd/kubectx@latest kubectx
+install_go_package github.com/ahmetb/kubectx/cmd/kubens@latest kubens
+
+# --- GITHUB EXTRAS ---
+
+# gh-dash (GitHub CLI dashboard)
+if command -v gh &> /dev/null; then
+    if ! gh extension list | grep -q "gh-dash"; then
+        echo -e "${c}Installing gh-dash extension...${r}"
+        gh extension install dlvhdr/gh-dash
+    else
+        echo -e "${c}gh-dash already installed.${r}"
+    fi
+else
+    echo -e "${c}gh not found, skipping gh-dash extension installation.${r}"
+fi
+
 # Configure Bat Theme
 echo -e "${c}Configuring Bat Theme...${r}"
 BAT_CONFIG_DIR="$(bat --config-dir)"

--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1055,10 +1055,20 @@ if ! command -v kubectl-krew &> /dev/null; then
     (
       set -x; cd "$(mktemp -d)" &&
       OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-      ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+      local arch
+      arch="$(uname -m)"
+      case "$arch" in
+        x86_64) ARCH="amd64" ;;
+        aarch64 | arm64) ARCH="arm64" ;;
+        arm*) ARCH="arm" ;;
+        *)
+          echo "Arquitetura não suportada para o Krew: $arch" >&2
+          exit 1
+          ;;
+      esac
       KREW="krew-${OS}_${ARCH}" &&
       curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
-      tar zxvf "${KREW}.tar.gz" &&
+      tar zxf "${KREW}.tar.gz" &&
       ./"${KREW}" install krew
     )
 else
@@ -1073,7 +1083,7 @@ install_go_package github.com/ahmetb/kubectx/cmd/kubens@latest kubens
 
 # gh-dash (GitHub CLI dashboard)
 if command -v gh &> /dev/null; then
-    if ! gh extension list | grep -q "gh-dash"; then
+    if ! gh extension list | grep -q "^dlvhdr/gh-dash\s"; then
         echo -e "${c}Installing gh-dash extension...${r}"
         gh extension install dlvhdr/gh-dash
     else

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -106,28 +106,34 @@ if [[ -z "$PROFILE" ]]; then
   if command -v "$GUM" &> /dev/null; then
     clear
     "$GUM" style \
-      --foreground "#ff7edb" --border-foreground "#36f9f6" --border double \
+      --foreground "#ff7edb" --border-foreground "#bd93f9" --border double \
       --align center --width 80 --margin "1 2" --padding "2 4" \
-      ' ___   ___ ___   __ ' \
-      '|__ \ / _ \__ \ / / ' \
-      '   ) | | | | ) / /_ ' \
-      '  / /| | | |/ / _ \ \' \
-      ' / /_| |_| / /| (_) |' \
-      '|____|\___/____\___/ ' \
+      '  ___   ___ ___   __  ' \
+      ' |__ \ / _ \__ \ / /  ' \
+      '    ) | | | | ) / /_  ' \
+      '   / /| | | |/ / _ \ \ ' \
+      '  / /_| |_| / /| (_) |' \
+      ' |____|\___/____\___/ ' \
       '' \
-      '⚡ DOTFILES 2026 EDITION ⚡' 'O Futuro do Desenvolvimento' \
-      '👾 THE SYNTHWAVE EXPERIENCE 👾'
+      '✨ DOTFILES 2026 EDITION ✨' 'O Futuro do Desenvolvimento' \
+      '👾 THE SYNTHWAVE EXPERIENCE 👾' \
+      '' \
+      '🚀 Aperte o cinto e prepare-se para a hipervelocidade!'
 
     echo ""
-    "$GUM" style --foreground "#36f9f6" --border normal --border-foreground "#36f9f6" --padding "1 2" --margin "1 0" "🚀 Escolha o perfil de instalação para turbinar sua máquina:"
+    "$GUM" style \
+      --foreground "#fede5d" \
+      --border rounded --border-foreground "#36f9f6" \
+      --padding "1 2" --margin "1 0" --align center --width 80 \
+      "Selecione o perfil de instalação para turbinar sua máquina:"
     echo ""
     PROFILE_CHOICE=$("$GUM" choose \
-      --cursor="▶ " \
-      --header="Selecione um perfil abaixo:" \
+      --cursor="🚀 " \
+      --header="Escolha o seu nível de poder:" \
       --header.foreground="#ff7edb" \
-      --cursor.foreground="#36f9f6" \
+      --cursor.foreground="#72f1b8" \
       --item.foreground="#f8f8f2" \
-      --selected.foreground="#72f1b8" \
+      --selected.foreground="#36f9f6" \
       "minimal   - Shell moderna, prompt limpo e editor básico." \
       "dev       - minimal + Runtimes JS/Python, Docker e Banco de Dados (Recomendado)." \
       "full      - dev + Apps extras de produtividade (Navegador, Slack, etc).")
@@ -186,7 +192,12 @@ done
 
 if command -v "$GUM" &> /dev/null; then
   echo ""
-  "$GUM" style --foreground "#36f9f6" "Selecione os módulos que deseja instalar (Espaço para marcar/desmarcar, Enter para confirmar):"
+  "$GUM" style \
+    --foreground "#fede5d" \
+    --border rounded --border-foreground "#ff7edb" \
+    --padding "1 2" --margin "1 0" --align center --width 80 \
+    "Selecione os módulos que deseja instalar:" \
+    "(Use Espaço para marcar/desmarcar, Enter para confirmar)"
   echo ""
 
   # Prepare choices with descriptions
@@ -205,11 +216,12 @@ if command -v "$GUM" &> /dev/null; then
   DEFAULTS=$(IFS=,; echo "${DEFAULTS_DESC[*]}")
 
   # Interactive selection
-  SELECTED_TEXT=$("$GUM" choose --no-limit --cursor="▶ " \
+  SELECTED_TEXT=$("$GUM" choose --no-limit --cursor="👉 " \
     --height=15 \
     --selected="${DEFAULTS}" \
-    --selected.foreground="#72f1b8" \
-    --cursor.foreground="#36f9f6" \
+    --selected.foreground="#36f9f6" \
+    --cursor.foreground="#ff7edb" \
+    --item.foreground="#f8f8f2" \
     "${CHOICES[@]}")
 
   # Extract module directories from the selected text
@@ -246,7 +258,13 @@ fi
 if [[ "$DRY_RUN" == false ]]; then
   if command -v "$GUM" &> /dev/null; then
     echo ""
-    if ! "$GUM" confirm --prompt.foreground "#ff7edb" --unselected.background "" --unselected.foreground "#f8f8f2" --selected.background "#bd93f9" --selected.foreground "#282a36" "Deseja prosseguir com a instalação destes módulos e transformar seu setup?"; then
+    if ! "$GUM" confirm \
+      --prompt.foreground "#ff7edb" \
+      --unselected.background "" \
+      --unselected.foreground "#f8f8f2" \
+      --selected.background "#72f1b8" \
+      --selected.foreground "#282a36" \
+      "Pronto para dar o salto hiperespacial e iniciar a instalação?"; then
       log "Instalação cancelada pelo usuário."
       exit 0
     fi


### PR DESCRIPTION
This PR enhances the main `setup-2026.sh` installer by making its UI more visually appealing, utilizing a synthwave aesthetic and advanced `gum` styling properties. It also expands the `cli-tools` module to include modern utilities such as `skate`, `melt`, `krew`, `kubectx`, `kubens`, and `gh-dash`, to further enrich the 2026 terminal experience.

---
*PR created automatically by Jules for task [11153478603709568011](https://jules.google.com/task/11153478603709568011) started by @juninmd*