### PR TITLE
feat: improve setup interface and add hyper-modern 2026 CLI apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1281,4 +1281,44 @@ fi
 # Hwatch (A modern alternative to the watch command)
 install_cargo_crate hwatch
 
+# --- HYPER-MODERN 2026 APPS ---
+
+# Jujutsu (jj - Git alternative)
+install_cargo_crate jj-cli jj
+
+# Trivy (Container security scanner)
+if ! command -v trivy &> /dev/null; then
+    echo -e "${c}Installing trivy...${r}"
+    wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/trivy.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
+    sudo apt-get update
+    sudo apt-get install -y trivy
+else
+    echo -e "${c}trivy already installed.${r}"
+fi
+
+# Earthly (Build automation)
+if ! command -v earthly &> /dev/null; then
+    echo -e "${c}Installing earthly...${r}"
+    sudo wget -q https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -O /usr/local/bin/earthly
+    sudo chmod +x /usr/local/bin/earthly
+else
+    echo -e "${c}earthly already installed.${r}"
+fi
+
+# Kind (Local Kubernetes)
+install_go_package sigs.k8s.io/kind@latest kind
+
+# hck (Fast cut replacement)
+install_cargo_crate hck
+
+# Cloudflared (Localhost tunneling)
+if ! command -v cloudflared &> /dev/null; then
+    echo -e "${c}Installing cloudflared...${r}"
+    sudo wget -q https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -O /usr/local/bin/cloudflared
+    sudo chmod +x /usr/local/bin/cloudflared
+else
+    echo -e "${c}cloudflared already installed.${r}"
+fi
+
 echo -e "${c}CLI Tools installed! Ensure ~/.local/bin, ~/.cargo/bin and ~/go/bin are in your PATH.${r}"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -653,6 +653,21 @@ if command -v hwatch &> /dev/null; then alias hwatch='hwatch'; fi
 EOT
 fi
 
+# Check if Hyper-Modern 2026 Apps are present in .zshrc
+if ! grep -q "# --- Hyper-Modern 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Hyper-Modern 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Hyper-Modern 2026 Apps ---
+if command -v jj &> /dev/null; then alias git-next='jj'; fi
+if command -v trivy &> /dev/null; then alias scan-container='trivy'; fi
+if command -v earthly &> /dev/null; then alias build='earthly'; fi
+if command -v kind &> /dev/null; then alias local-k8s='kind'; fi
+if command -v hck &> /dev/null; then alias cut2='hck'; fi
+if command -v cloudflared &> /dev/null; then alias cf-tunnel='cloudflared tunnel'; fi
+EOT
+fi
+
 # Update zoxide to use cd alias if present in existing config
 sed -i 's/eval "$(zoxide init zsh)"/eval "$(zoxide init zsh --cmd cd)"/' "$ZSHRC"
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -69,7 +69,7 @@ run_module() {
     run_step "$progress_prefix Executando módulo: $module" "$script"
   else
     if command -v "$GUM" &> /dev/null; then
-      if "$GUM" spin --spinner minidot --title "$($GUM style --foreground "#72f1b8" "$progress_prefix Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"; then
+      if "$GUM" spin --spinner moon --title "$($GUM style --foreground "#72f1b8" "$progress_prefix Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"; then
         echo "$($GUM style --foreground "#72f1b8" "✔") $($GUM style --foreground "#f8f8f2" "$progress_prefix Módulo") $($GUM style --foreground "#fede5d" "$module") $($GUM style --foreground "#f8f8f2" "instalado com sucesso!")"
       else
         echo "$($GUM style --foreground "#ff7edb" "✖") $($GUM style --foreground "#f8f8f2" "$progress_prefix Erro ao instalar módulo") $($GUM style --foreground "#fede5d" "$module")$($GUM style --foreground "#f8f8f2" ". Verifique os logs.")"
@@ -304,15 +304,20 @@ ELAPSED_MINUTES=$(($ELAPSED_TIME / 60))
 ELAPSED_SECONDS=$(($ELAPSED_TIME % 60))
 
 if command -v "$GUM" &> /dev/null; then
-  "$GUM" style \
+  ART_BOX=$("$GUM" style \
+    --foreground "#ff7edb" --border double --border-foreground "#ff7edb" \
+    --padding "1 3" --margin "1 1" \
+    ' 🤖 ' 'SYS' ' OK ')
+  TEXT_BOX=$("$GUM" style \
     --foreground "#282a36" --background "#72f1b8" --border-foreground "#72f1b8" \
-    --border thick --align center --width 80 --margin "2 2" --padding "1 2" \
+    --border thick --align center --width 60 --margin "2 2" --padding "1 2" \
     "🚀 OVERRIDE DO SISTEMA COMPLETO: Perfil '$PROFILE' ativado! 🛸" \
     "Tempo total: ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s" \
     "" \
     "Por favor, feche este terminal e abra um novo para carregar todas as configurações." \
     "" \
-    "📂 Logs de instalação disponíveis em: /tmp/setup-2026-*.log"
+    "📂 Logs de instalação disponíveis em: /tmp/setup-2026-*.log")
+  echo "$("$GUM" join --align center "$ART_BOX" "$TEXT_BOX")"
 else
   log "Finalizado com sucesso em ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s. Reinicie seu terminal."
   log "Logs de instalação disponíveis em: /tmp/setup-2026-*.log"


### PR DESCRIPTION
This pull request introduces significant interface improvements to the main installation script and expands the suite of developer tools with modern 2026 alternatives.

**Interface Improvements:**
- Changed the background `gum` loading spinner from `minidot` to `moon`.
- Redesigned the completion summary screen at the end of the installation process. It now displays a stylized, double-bordered ASCII art box ('🤖 SYS OK') rendered side-by-side with the installation summary text using `gum join`.

**New CLI Tools & Integrations:**
- Installed **Jujutsu (`jj`)**, a Git-compatible version control system, via Cargo.
- Installed **Trivy**, a comprehensive security scanner, via Apt.
- Installed **Earthly**, a container-based build automation tool, via a direct binary download.
- Installed **Kind**, a tool for running local Kubernetes clusters using Docker container nodes, via Go.
- Installed **hck**, a fast `cut` replacement, via Cargo.
- Installed **Cloudflared**, for secure localhost tunneling, via direct binary download.
- Created corresponding shell aliases in the auto-generated `.zshrc` block, making these tools readily available out of the box (e.g., `alias git-next='jj'`, `alias build='earthly'`).

---
*PR created automatically by Jules for task [8220705616738210428](https://jules.google.com/task/8220705616738210428) started by @juninmd*