### PR TITLE
feat: improve interface and add more 2026 apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1379,4 +1379,46 @@ else
     echo -e "${c}cloudflared already installed.${r}"
 fi
 
+# --- NEWEST 2026 APPS ---
+
+# jo (JSON output utility)
+if ! command -v jo &> /dev/null; then
+    echo -e "${c}Installing jo...${r}"
+    sudo apt install -y jo
+else
+    echo -e "${c}jo already installed.${r}"
+fi
+
+# k6 (Modern load testing tool)
+if ! command -v k6 &> /dev/null; then
+    echo -e "${c}Installing k6...${r}"
+    install_go_package go.k6.io/k6@latest k6
+else
+    echo -e "${c}k6 already installed.${r}"
+fi
+
+# dolt (Git for data)
+if ! command -v dolt &> /dev/null; then
+    echo -e "${c}Installing dolt...${r}"
+    sudo bash -c 'curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash'
+else
+    echo -e "${c}dolt already installed.${r}"
+fi
+
+# turso (Edge database CLI)
+if ! command -v turso &> /dev/null; then
+    echo -e "${c}Installing turso...${r}"
+    curl -sL https://get.turso.tech/install.sh | bash
+else
+    echo -e "${c}turso already installed.${r}"
+fi
+
+# flyctl (Fly.io CLI)
+if ! command -v flyctl &> /dev/null; then
+    echo -e "${c}Installing flyctl...${r}"
+    curl -L https://fly.io/install.sh | sh
+else
+    echo -e "${c}flyctl already installed.${r}"
+fi
+
 echo -e "${c}CLI Tools installed! Ensure ~/.local/bin, ~/.cargo/bin and ~/go/bin are in your PATH.${r}"

--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1400,7 +1400,7 @@ fi
 # dolt (Git for data)
 if ! command -v dolt &> /dev/null; then
     echo -e "${c}Installing dolt...${r}"
-    sudo bash -c 'curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash'
+    curl -sL https://github.com/dolthub/dolt/releases/latest/download/install.sh -o /tmp/dolt_install.sh && sudo bash /tmp/dolt_install.sh && rm /tmp/dolt_install.sh
 else
     echo -e "${c}dolt already installed.${r}"
 fi

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -233,7 +233,7 @@ if command -v moar &> /dev/null; then
     export MOAR='--statusbar=bold --no-linenumbers'
     alias less='moar'
 fi
-if command -v viddy &> /dev/null; then alias watch='viddy'; fi
+if command -v hwatch &> /dev/null; then alias watch='hwatch'; fi
 if command -v sesh &> /dev/null; then alias s='sesh connect'; fi
 
 # --- Interface Improvements 2026 ---
@@ -393,7 +393,7 @@ if command -v moar &> /dev/null; then
     export MOAR='--statusbar=bold --no-linenumbers'
     alias less='moar'
 fi
-if command -v viddy &> /dev/null; then alias watch='viddy'; fi
+if command -v hwatch &> /dev/null; then alias watch='hwatch'; fi
 if command -v sesh &> /dev/null; then alias s='sesh connect'; fi
 EOT
 fi
@@ -688,6 +688,20 @@ if command -v k3d &> /dev/null; then alias k8s-docker='k3d'; fi
 if command -v helm &> /dev/null; then alias k8s-pkg='helm'; fi
 if command -v kustomize &> /dev/null; then alias k8s-config='kustomize'; fi
 if command -v ngrok &> /dev/null; then alias proxy='ngrok'; fi
+EOT
+fi
+
+# Check if Newest 2026 Apps are present in .zshrc
+if ! grep -q "# --- Newest 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Newest 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Newest 2026 Apps ---
+if command -v jo &> /dev/null; then alias json-out='jo'; fi
+if command -v k6 &> /dev/null; then alias loadtest='k6'; fi
+if command -v dolt &> /dev/null; then alias data-git='dolt'; fi
+if command -v turso &> /dev/null; then alias db-edge='turso'; fi
+if command -v flyctl &> /dev/null; then alias cloud-deploy='flyctl'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -110,11 +110,12 @@ if [[ -z "$PROFILE" ]]; then
     "$GUM" style \
       --foreground "#ff7edb" --border-foreground "#bd93f9" --border double \
       --align center --width 80 --margin "1 2" --padding "2 4" \
-      '  ____   ___  ____   __   ' \
-      ' |___ \ / _ \|___ \ / /_  ' \
-      '   __) | | | | __) | |_ \ ' \
-      '  / __/| |_| |/ __/|  _  |' \
-      ' |_____|\___/|_____|_| |_|' \
+      '  ___   ___  ___  __  ' \
+      ' |__ \ / _ \|__ \/ /  ' \
+      '    ) | | | |  ) / /_ ' \
+      '   / /| |_| | / / _ \ ' \
+      '  / /_|  _  |/ / (_) |' \
+      ' |____|\___/|____\___/' \
       '' \
       '✨ DOTFILES 2026 EDITION ✨' \
       'O Futuro do Desenvolvimento Já Chegou' \


### PR DESCRIPTION
- Updated the "2026" ascii art banner in `setup-2026.sh` to a more detailed block style to fit the aesthetic.
- Added installation commands for `jo`, `k6`, `dolt`, `turso`, and `flyctl` to the `programas/cli-tools/setup.sh` script.
- Switched the `watch` alias from `viddy` to `hwatch` in `programas/zsh/setup.sh` as `hwatch` is part of the toolset.
- Added zsh aliases for the newly installed apps: `json-out`, `loadtest`, `data-git`, `db-edge`, and `cloud-deploy`.

---
*PR created automatically by Jules for task [7069365791714475705](https://jules.google.com/task/7069365791714475705) started by @juninmd*