### PR TITLE
Improve setup interface and add new 2026 apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1421,4 +1421,15 @@ else
     echo -e "${c}flyctl already installed.${r}"
 fi
 
+# Kalker (Math calculator)
+install_cargo_crate kalker
+
+# Ugrep (Ultra fast grep)
+if ! command -v ugrep &> /dev/null; then
+    echo -e "${c}Installing ugrep...${r}"
+    sudo apt install -y ugrep
+else
+    echo -e "${c}ugrep already installed.${r}"
+fi
+
 echo -e "${c}CLI Tools installed! Ensure ~/.local/bin, ~/.cargo/bin and ~/go/bin are in your PATH.${r}"

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -253,6 +253,10 @@ if command -v tspin &> /dev/null; then alias logs='tspin'; fi
 if command -v slumber &> /dev/null; then alias http-ui='slumber'; fi
 if command -v jqp &> /dev/null; then alias jq-ui='jqp'; fi
 
+# --- Brand New 2026 Apps ---
+if command -v kalker &> /dev/null; then alias calc2='kalker'; fi
+if command -v ugrep &> /dev/null; then alias ug='ugrep'; fi
+
 # --- Extra 2026 Apps ---
 if command -v kdash &> /dev/null; then alias kdash='kdash'; fi
 if command -v stern &> /dev/null; then alias stern='stern'; fi
@@ -702,6 +706,17 @@ if command -v k6 &> /dev/null; then alias loadtest='k6'; fi
 if command -v dolt &> /dev/null; then alias data-git='dolt'; fi
 if command -v turso &> /dev/null; then alias db-edge='turso'; fi
 if command -v flyctl &> /dev/null; then alias cloud-deploy='flyctl'; fi
+EOT
+fi
+
+# Check if Brand New 2026 Apps are present in .zshrc
+if ! grep -q "# --- Brand New 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Brand New 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Brand New 2026 Apps ---
+if command -v kalker &> /dev/null; then alias calc2='kalker'; fi
+if command -v ugrep &> /dev/null; then alias ug='ugrep'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -69,7 +69,7 @@ run_module() {
     run_step "$progress_prefix Executando módulo: $module" "$script"
   else
     if command -v "$GUM" &> /dev/null; then
-      if "$GUM" spin --spinner moon --title "$($GUM style --foreground "#72f1b8" "$progress_prefix Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"; then
+      if "$GUM" spin --spinner dot --spinner.foreground "#ff7edb" --title "$($GUM style --foreground "#72f1b8" "$progress_prefix Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"; then
         echo "$($GUM style --foreground "#72f1b8" "✔") $($GUM style --foreground "#f8f8f2" "$progress_prefix Módulo") $($GUM style --foreground "#fede5d" "$module") $($GUM style --foreground "#f8f8f2" "instalado com sucesso!")"
       else
         echo "$($GUM style --foreground "#ff7edb" "✖") $($GUM style --foreground "#f8f8f2" "$progress_prefix Erro ao instalar módulo") $($GUM style --foreground "#fede5d" "$module")$($GUM style --foreground "#f8f8f2" ". Verifique os logs.")"
@@ -105,7 +105,7 @@ done
 if [[ -z "$PROFILE" ]]; then
   if command -v "$GUM" &> /dev/null; then
     clear
-    "$GUM" style --foreground "#fede5d" --align center --width 80 "Welcome to the ultimate terminal experience."
+    "$GUM" style --foreground "#fede5d" --align center --width 80 "BEM-VINDO A REVOLUÇÃO TERMINAL DE 2026"
 
     "$GUM" style \
       --foreground "#ff7edb" --border-foreground "#bd93f9" --border double \
@@ -299,6 +299,9 @@ for module in "${MODULES[@]}"; do
   fi
 
   run_module "$module" "$CURRENT_MODULE" "$TOTAL_MODULES"
+  if command -v "$GUM" &> /dev/null; then
+    echo "$("$GUM" style --foreground "#bd93f9" -- "----------------------------------------")"
+  fi
   CURRENT_MODULE=$((CURRENT_MODULE + 1))
 done
 
@@ -309,12 +312,12 @@ ELAPSED_SECONDS=$(($ELAPSED_TIME % 60))
 
 if command -v "$GUM" &> /dev/null; then
   ART_BOX=$("$GUM" style \
-    --foreground "#ff7edb" --border double --border-foreground "#ff7edb" \
-    --padding "1 3" --margin "1 1" \
+    --foreground "#ff7edb" --border rounded --border-foreground "#ff7edb" \
+    --padding "2 4" --margin "1 1" \
     ' 🤖 ' 'SYS' ' OK ')
   TEXT_BOX=$("$GUM" style \
     --foreground "#282a36" --background "#72f1b8" --border-foreground "#72f1b8" \
-    --border thick --align center --width 65 --margin "2 2" --padding "1 2" \
+    --border thick --align center --width 75 --margin "2 2" --padding "1 2" \
     "🚀 TRANSMISSÃO CONCLUÍDA: Perfil '$PROFILE' ativado! 🛸" \
     "Tempo total de salto: ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s" \
     "" \

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -300,7 +300,7 @@ for module in "${MODULES[@]}"; do
 
   run_module "$module" "$CURRENT_MODULE" "$TOTAL_MODULES"
   if command -v "$GUM" &> /dev/null; then
-    echo "$("$GUM" style --foreground "#bd93f9" -- "----------------------------------------")"
+    "$GUM" style --foreground "#bd93f9" -- "----------------------------------------"
   fi
   CURRENT_MODULE=$((CURRENT_MODULE + 1))
 done


### PR DESCRIPTION
This submission improves the `setup-2026.sh` terminal interface by:
- Adding a stylized "BEM-VINDO A REVOLUÇÃO TERMINAL DE 2026" header.
- Changing the installation `gum spin` to use a pink dot spinner instead of a moon.
- Adding a visual horizontal separator between module executions.
- Expanding the final success message box and updating its padding/borders.

It also introduces two new "2026 Apps" to enhance the terminal experience:
- `kalker`: A powerful math calculator.
- `ugrep`: An ultra-fast grep alternative.
Corresponding aliases (`calc2` and `ug`) were added to the `.zshrc` setup script.

---
*PR created automatically by Jules for task [16830901956384400140](https://jules.google.com/task/16830901956384400140) started by @juninmd*