### PR TITLE
feat: improve setup UI and add modern CLI tools

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1351,6 +1351,32 @@ install_cargo_crate rustscan
 # Diskonaut (Terminal disk space navigator)
 install_cargo_crate diskonaut
 
+# --- BRAND NEW 2026 APPS PART II ---
+
+# Xplr (TUI file explorer)
+install_cargo_crate xplr
+
+# Systeroid (Kernel parameter manager)
+install_cargo_crate systeroid
+
+# Systemctl-tui (Systemd TUI)
+install_cargo_crate systemctl-tui
+
+# Bruno CLI (API testing)
+if ! command -v bru &> /dev/null; then
+    echo -e "${c}Installing bruno-cli...${r}"
+    if command -v npm &> /dev/null; then
+        sudo npm install -g @usebruno/cli
+    else
+        echo -e "${c}npm not found, skipping bruno-cli installation.${r}"
+    fi
+else
+    echo -e "${c}bruno-cli already installed.${r}"
+fi
+
+# Mani (Multi-repository management)
+install_go_package github.com/alajmo/mani@latest mani
+
 # --- EXTRA 2026 APPS ---
 
 # Sniffnet (Application to comfortably monitor your network traffic)

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -746,6 +746,20 @@ if command -v newsboat &> /dev/null; then alias rss='newsboat'; fi
 EOT
 fi
 
+# Check if Super 2026 Apps are present in .zshrc
+if ! grep -q "# --- Super 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Super 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Super 2026 Apps ---
+if command -v xplr &> /dev/null; then alias explore='xplr'; fi
+if command -v systeroid &> /dev/null; then alias kernel-ui='systeroid'; fi
+if command -v systemctl-tui &> /dev/null; then alias sys-ui='systemctl-tui'; fi
+if command -v bru &> /dev/null; then alias api-test='bru'; fi
+if command -v mani &> /dev/null; then alias repos='mani'; fi
+EOT
+fi
+
 # Update zoxide to use cd alias if present in existing config
 sed -i 's/eval "$(zoxide init zsh)"/eval "$(zoxide init zsh --cmd cd)"/' "$ZSHRC"
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -127,12 +127,24 @@ if [[ -z "$PROFILE" ]]; then
       '⚡ Injetando código na matrix...' \
       '🔮 Bem-vindo à nova era.')
 
-    "$GUM" join --align center "$HEADER" "$INFO"
+    OS_INFO=$(uname -s)
+    ARCH_INFO=$(uname -m)
+    USER_INFO=$(whoami)
+    SYS_INFO=$("$GUM" style \
+      --foreground "#f8f8f2" --border-foreground "#72f1b8" --border rounded \
+      --align left --width 30 --margin "1 2" --padding "2 3" \
+      '💻 SYSTEM INFO' \
+      '' \
+      "👤 User: $($GUM style --foreground "#fede5d" "$USER_INFO")" \
+      "🖥️ OS:   $($GUM style --foreground "#ff7edb" "$OS_INFO")" \
+      "⚙️ Arch: $($GUM style --foreground "#36f9f6" "$ARCH_INFO")")
+
+    "$GUM" join --align center "$HEADER" "$("$GUM" join --align center "$INFO" "$SYS_INFO")"
     echo ""
 
     "$GUM" style \
       --foreground "#fede5d" \
-      --border rounded --border-foreground "#36f9f6" \
+      --border rounded --border-foreground "#ff7edb" \
       --padding "1 2" --margin "1 0" --align center --width 100 \
       "🌐 Iniciando Protocolo de Setup 2026 🌐" \
       "Selecione o perfil de instalação para turbinar sua máquina:"

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -139,7 +139,7 @@ if [[ -z "$PROFILE" ]]; then
       "🖥️ OS:   $($GUM style --foreground "#ff7edb" "$OS_INFO")" \
       "⚙️ Arch: $($GUM style --foreground "#36f9f6" "$ARCH_INFO")")
 
-    "$GUM" join --align center "$HEADER" "$("$GUM" join --align center "$INFO" "$SYS_INFO")"
+    "$GUM" join --vertical --align center "$HEADER" "$("$GUM" join --align center "$INFO" "$SYS_INFO")"
     echo ""
 
     "$GUM" style \


### PR DESCRIPTION
This PR addresses the user's request to "Improve interface and add more useful 2026 apps". 

1. **Interface Improvement**: It enhances `setup-2026.sh` by introducing a new "SYSTEM INFO" section to the splash screen that dynamically outputs the current User, OS, and Architecture utilizing existing `gum` styling. It also refines the theme by adjusting border colors slightly for a more consistent Synthwave look.
2. **New Apps**: Adds five new modern terminal utilities (`xplr`, `systeroid`, `systemctl-tui`, `bruno-cli`, `mani`) to the `cli-tools` setup script and sets up corresponding Zsh aliases for easy usage.

Tested locally with a full script dry-run.

---
*PR created automatically by Jules for task [13189960814133947781](https://jules.google.com/task/13189960814133947781) started by @juninmd*