### PR TITLE
Enhance setup script interface and add missing 2026 CLI apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1377,6 +1377,21 @@ fi
 # Mani (Multi-repository management)
 install_go_package github.com/alajmo/mani@latest mani
 
+# Xcp (Extended cp)
+install_cargo_crate xcp
+
+# Dysk (Linux disks info)
+install_cargo_crate dysk
+
+# So (StackOverflow in terminal)
+install_cargo_crate so
+
+# Inlyne (GPU powered markdown viewer)
+install_cargo_crate inlyne
+
+# Ncspot (Cross-platform Spotify client)
+install_cargo_crate ncspot
+
 # --- EXTRA 2026 APPS ---
 
 # Sniffnet (Application to comfortably monitor your network traffic)

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -757,6 +757,11 @@ if command -v systeroid &> /dev/null; then alias kernel-ui='systeroid'; fi
 if command -v systemctl-tui &> /dev/null; then alias sys-ui='systemctl-tui'; fi
 if command -v bru &> /dev/null; then alias api-test='bru'; fi
 if command -v mani &> /dev/null; then alias repos='mani'; fi
+if command -v xcp &> /dev/null; then alias cp2='xcp'; fi
+if command -v dysk &> /dev/null; then alias mounts='dysk'; fi
+if command -v so &> /dev/null; then alias stackoverflow='so'; fi
+if command -v inlyne &> /dev/null; then alias md-gpu='inlyne'; fi
+if command -v ncspot &> /dev/null; then alias spotify='ncspot'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -130,14 +130,18 @@ if [[ -z "$PROFILE" ]]; then
     OS_INFO=$(uname -s)
     ARCH_INFO=$(uname -m)
     USER_INFO=$(whoami)
+    HOST_INFO=$(hostname)
+    SHELL_INFO=$(basename "$SHELL")
     SYS_INFO=$("$GUM" style \
       --foreground "#f8f8f2" --border-foreground "#72f1b8" --border rounded \
       --align left --width 30 --margin "1 2" --padding "2 3" \
       '💻 SYSTEM INFO' \
       '' \
       "👤 User: $($GUM style --foreground "#fede5d" "$USER_INFO")" \
+      "🏠 Host: $($GUM style --foreground "#bd93f9" "$HOST_INFO")" \
       "🖥️ OS:   $($GUM style --foreground "#ff7edb" "$OS_INFO")" \
-      "⚙️ Arch: $($GUM style --foreground "#36f9f6" "$ARCH_INFO")")
+      "⚙️ Arch: $($GUM style --foreground "#36f9f6" "$ARCH_INFO")" \
+      "🐚 Shell: $($GUM style --foreground "#fede5d" "$SHELL_INFO")")
 
     "$GUM" join --vertical --align center "$HEADER" "$("$GUM" join --align center "$INFO" "$SYS_INFO")"
     echo ""

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -130,17 +130,17 @@ if [[ -z "$PROFILE" ]]; then
     OS_INFO=$(uname -s)
     ARCH_INFO=$(uname -m)
     USER_INFO=$(whoami)
-    HOST_INFO=$(hostname)
-    SHELL_INFO=$(basename "$SHELL")
+    HOST_INFO=${HOSTNAME:-$(hostname 2>/dev/null || echo "unknown")}
+    SHELL_INFO=$(basename "${SHELL:-/bin/bash}")
     SYS_INFO=$("$GUM" style \
       --foreground "#f8f8f2" --border-foreground "#72f1b8" --border rounded \
       --align left --width 30 --margin "1 2" --padding "2 3" \
       '💻 SYSTEM INFO' \
       '' \
-      "👤 User: $($GUM style --foreground "#fede5d" "$USER_INFO")" \
-      "🏠 Host: $($GUM style --foreground "#bd93f9" "$HOST_INFO")" \
-      "🖥️ OS:   $($GUM style --foreground "#ff7edb" "$OS_INFO")" \
-      "⚙️ Arch: $($GUM style --foreground "#36f9f6" "$ARCH_INFO")" \
+      "👤 User:  $($GUM style --foreground "#fede5d" "$USER_INFO")" \
+      "🏠 Host:  $($GUM style --foreground "#bd93f9" "$HOST_INFO")" \
+      "🖥️ OS:    $($GUM style --foreground "#ff7edb" "$OS_INFO")" \
+      "⚙️ Arch:  $($GUM style --foreground "#36f9f6" "$ARCH_INFO")" \
       "🐚 Shell: $($GUM style --foreground "#fede5d" "$SHELL_INFO")")
 
     "$GUM" join --vertical --align center "$HEADER" "$("$GUM" join --align center "$INFO" "$SYS_INFO")"


### PR DESCRIPTION
This pull request improves the user interface of the `setup-2026.sh` interactive script and fills in missing 2026 CLI applications requested by the user.

**Changes:**
1.  **Interface Improvements (`setup-2026.sh`)**:
    *   Added `Hostname` and `Shell` variables to the `SYS_INFO` panel for better context.
    *   Applied the user's preferred Synthwave '84 color palette (e.g., `#bd93f9`, `#fede5d`) to the new attributes to maintain a consistent aesthetic.
2.  **New App Installations (`programas/cli-tools/setup.sh`)**:
    *   Added `xcp` (Extended cp)
    *   Added `dysk` (Linux disks info)
    *   Added `so` (StackOverflow in terminal)
    *   Added `inlyne` (GPU powered markdown viewer)
    *   Added `ncspot` (Cross-platform Spotify client)
3.  **Alias Configurations (`programas/zsh/setup.sh`)**:
    *   `cp2='xcp'`
    *   `mounts='dysk'`
    *   `stackoverflow='so'`
    *   `md-gpu='inlyne'`
    *   `spotify='ncspot'`

---
*PR created automatically by Jules for task [7083263323590757943](https://jules.google.com/task/7083263323590757943) started by @juninmd*