### PR TITLE
Improve interface and add more useful 2026 apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -1561,3 +1561,55 @@ else
 fi
 
 echo -e "${c}CLI Tools installed! Ensure ~/.local/bin, ~/.cargo/bin and ~/go/bin are in your PATH.${r}"
+# --- BEYOND 2026 APPS ---
+
+# Aider-chat (AI pair programming)
+if ! command -v aider &> /dev/null; then
+    echo -e "${c}Installing aider-chat...${r}"
+    if command -v pipx &> /dev/null; then
+        pipx install aider-chat
+    else
+        pip3 install aider-chat --break-system-packages 2>/dev/null || pip3 install aider-chat
+    fi
+else
+    echo -e "${c}aider-chat already installed.${r}"
+fi
+
+# Repomix (Pack repository into AI prompt)
+if ! command -v repomix &> /dev/null; then
+    echo -e "${c}Installing repomix...${r}"
+    if command -v npm &> /dev/null; then
+        sudo npm install -g repomix
+    else
+        echo -e "${c}npm not found, skipping repomix installation.${r}"
+    fi
+else
+    echo -e "${c}repomix already installed.${r}"
+fi
+
+# Gitingest (Replace git clone with AI friendly prompt)
+if ! command -v gitingest &> /dev/null; then
+    echo -e "${c}Installing gitingest...${r}"
+    pip3 install gitingest --break-system-packages 2>/dev/null || pip3 install gitingest
+else
+    echo -e "${c}gitingest already installed.${r}"
+fi
+
+# Harlequin (SQL IDE for terminal)
+if ! command -v harlequin &> /dev/null; then
+    echo -e "${c}Installing harlequin...${r}"
+    pip3 install harlequin --break-system-packages 2>/dev/null || pip3 install harlequin
+else
+    echo -e "${c}harlequin already installed.${r}"
+fi
+
+# Slumber (Terminal HTTP Client)
+install_cargo_crate slumber
+
+# Plandex (AI coding engine)
+if ! command -v plandex &> /dev/null; then
+    echo -e "${c}Installing plandex...${r}"
+    curl -sL https://plandex.ai/install.sh | sh
+else
+    echo -e "${c}plandex already installed.${r}"
+fi

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -765,6 +765,20 @@ if command -v ncspot &> /dev/null; then alias spotify='ncspot'; fi
 EOT
 fi
 
+# Check if Beyond 2026 Apps are present in .zshrc
+if ! grep -q "# --- Beyond 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Beyond 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Beyond 2026 Apps ---
+if command -v repomix &> /dev/null; then alias repo-pack='repomix'; fi
+if command -v gitingest &> /dev/null; then alias ingest='gitingest'; fi
+if command -v harlequin &> /dev/null; then alias sql-ide='harlequin'; fi
+if command -v slumber &> /dev/null; then alias http-ui='slumber'; fi
+if command -v plandex &> /dev/null; then alias plandex-ai='plandex'; fi
+EOT
+fi
+
 # Update zoxide to use cd alias if present in existing config
 sed -i 's/eval "$(zoxide init zsh)"/eval "$(zoxide init zsh --cmd cd)"/' "$ZSHRC"
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -134,7 +134,7 @@ if [[ -z "$PROFILE" ]]; then
     HOST_INFO=${HOSTNAME:-$(hostname 2>/dev/null || echo "unknown")}
     SHELL_INFO=$(basename "${SHELL:-/bin/bash}")
     SYS_INFO=$("$GUM" style \
-      --foreground "#f8f8f2" --border-foreground "#72f1b8" --border rounded \
+      --foreground "#f8f8f2" --border-foreground "#bd93f9" --border double \
       --align left --width 30 --margin "1 2" --padding "2 3" \
       '💻 SYSTEM INFO' \
       '' \
@@ -347,16 +347,16 @@ if command -v "$GUM" &> /dev/null; then
     '' \
     '👾 2026')
   TEXT_BOX=$("$GUM" style \
-    --foreground "#282a36" --background "#72f1b8" --border-foreground "#72f1b8" \
+      --foreground "#f8f8f2" --background "#282a36" --border-foreground "#ff7edb" \
     --border thick --align center --width 65 --margin "1 2" --padding "1 2" \
-    "🚀 TRANSMISSÃO CONCLUÍDA! 🛸" \
-    "Perfil $($GUM style --foreground "#ff7edb" --background "#282a36" " $PROFILE ") ativado com sucesso!" \
-    "Tempo total de salto: ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s" \
+      "🚀 $($GUM style --foreground "#36f9f6" "TRANSMISSÃO CONCLUÍDA!") 🛸" \
+      "Perfil $($GUM style --foreground "#282a36" --background "#72f1b8" " $PROFILE ") ativado com sucesso!" \
+      "Tempo total de salto: $($GUM style --foreground "#fede5d" "${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s")" \
     "" \
     "A matrix foi atualizada e está pronta para uso." \
     "Feche este terminal e abra um novo para carregar sua nova realidade." \
     "" \
-    "📂 Logs salvos em: /tmp/setup-2026-*.log")
+      "📂 $($GUM style --foreground "#bd93f9" "Logs salvos em: /tmp/setup-2026-*.log")")
   echo "$("$GUM" join --align center "$ART_BOX" "$TEXT_BOX")"
 else
   log "Finalizado com sucesso em ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s. Reinicie seu terminal."


### PR DESCRIPTION
- Enhances `setup-2026.sh` interface with refined layout (`double` borders) and exact Synthwave hex codes (`#36f9f6`, `#ff7edb`, `#72f1b8`, `#fede5d`, `#bd93f9`, `#282a36`).
- Appends new "BEYOND 2026 APPS" section to `programas/cli-tools/setup.sh` for installing `aider-chat`, `repomix`, `gitingest`, `harlequin`, `slumber`, and `plandex`.
- Appends new aliases to `programas/zsh/setup.sh` configuration for quick access to the new CLI applications.

---
*PR created automatically by Jules for task [1975502164487148890](https://jules.google.com/task/1975502164487148890) started by @juninmd*