### PR TITLE
feat: improve setup interface and add new 2026 apps

### DIFF
--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -964,6 +964,35 @@ else
     echo -e "${c}plandex already installed.${r}"
 fi
 
+# --- 2026 EXPERIMENTAL APPS ---
+
+# Dotenvx (Better dotenv)
+if ! command -v dotenvx &> /dev/null; then
+    echo -e "${c}Installing dotenvx...${r}"
+    curl -fsS https://dotenvx.sh/ | sh
+else
+    echo -e "${c}dotenvx already installed.${r}"
+fi
+
+# Zrok (Ngrok alternative)
+if ! command -v zrok &> /dev/null; then
+    echo -e "${c}Installing zrok...${r}"
+    curl -sSL https://raw.githubusercontent.com/openziti/zrok/main/install/setup.sh | sudo bash
+else
+    echo -e "${c}zrok already installed.${r}"
+fi
+
+# Git-sim (Visually simulate Git operations)
+if ! command -v git-sim &> /dev/null; then
+    echo -e "${c}Installing git-sim...${r}"
+    pip3 install git-sim --break-system-packages 2>/dev/null || pip3 install git-sim
+else
+    echo -e "${c}git-sim already installed.${r}"
+fi
+
+# Charm (The Charm Tool)
+install_go_package github.com/charmbracelet/charm@latest charm
+
 # Shell-GPT (AI in terminal)
 if ! command -v sgpt &> /dev/null; then
     echo -e "${c}Installing shell-gpt...${r}"

--- a/programas/cli-tools/setup.sh
+++ b/programas/cli-tools/setup.sh
@@ -969,7 +969,7 @@ fi
 # Dotenvx (Better dotenv)
 if ! command -v dotenvx &> /dev/null; then
     echo -e "${c}Installing dotenvx...${r}"
-    curl -fsS https://dotenvx.sh/ | sh
+    { curl -fsS https://dotenvx.sh/ -o /tmp/dotenvx_install.sh && sh /tmp/dotenvx_install.sh; }
 else
     echo -e "${c}dotenvx already installed.${r}"
 fi
@@ -977,7 +977,7 @@ fi
 # Zrok (Ngrok alternative)
 if ! command -v zrok &> /dev/null; then
     echo -e "${c}Installing zrok...${r}"
-    curl -sSL https://raw.githubusercontent.com/openziti/zrok/main/install/setup.sh | sudo bash
+    { curl -sSL https://raw.githubusercontent.com/openziti/zrok/main/install/setup.sh -o /tmp/zrok_install.sh && sudo bash /tmp/zrok_install.sh; }
 else
     echo -e "${c}zrok already installed.${r}"
 fi

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -731,8 +731,8 @@ if command -v ugrep &> /dev/null; then alias ug='ugrep'; fi
 if command -v termscp &> /dev/null; then alias scp-ui='termscp'; fi
 if command -v lychee &> /dev/null; then alias links='lychee'; fi
 if command -v bluetuith &> /dev/null; then alias bt-ui='bluetuith'; fi
-if command -v czg &> /dev/null; then alias c='czg'; fi
-if command -v batman &> /dev/null; then alias man='batman'; fi
+if command -v czg &> /dev/null; then alias cz='czg'; fi
+if command -v batman &> /dev/null; then alias manb='batman'; fi
 EOT
 fi
 

--- a/programas/zsh/setup.sh
+++ b/programas/zsh/setup.sh
@@ -331,7 +331,7 @@ if command -v cheat &> /dev/null; then alias cheatsheet='cheat'; fi
 # --- Latest 2026 Apps ---
 if command -v yt-dlp &> /dev/null; then alias ytdl='yt-dlp'; fi
 if command -v porsmo &> /dev/null; then alias pomodoro='porsmo'; fi
-if command -v rustscan &> /dev/null; then alias rscan='rustscan'; fi
+if command -v rustscan &> /dev/null; then alias scan='rustscan'; fi
 if command -v diskonaut &> /dev/null; then alias disk-vis='diskonaut'; fi
 
 # --- Cutting-Edge 2026 Apps ---
@@ -349,6 +349,12 @@ if command -v k3d &> /dev/null; then alias k8s-docker='k3d'; fi
 if command -v helm &> /dev/null; then alias k8s-pkg='helm'; fi
 if command -v kustomize &> /dev/null; then alias k8s-config='kustomize'; fi
 if command -v ngrok &> /dev/null; then alias proxy='ngrok'; fi
+
+# --- Experimental 2026 Apps ---
+if command -v dotenvx &> /dev/null; then alias envx='dotenvx'; fi
+if command -v zrok &> /dev/null; then alias tunnel-alt='zrok'; fi
+if command -v git-sim &> /dev/null; then alias gsim='git-sim'; fi
+if command -v charm &> /dev/null; then alias charm-tools='charm'; fi
 
 # --- End Custom Configuration ---
 EOT
@@ -641,7 +647,7 @@ if ! grep -q "# --- Latest 2026 Apps ---" "$ZSHRC"; then
 # --- Latest 2026 Apps ---
 if command -v yt-dlp &> /dev/null; then alias ytdl='yt-dlp'; fi
 if command -v porsmo &> /dev/null; then alias pomodoro='porsmo'; fi
-if command -v rustscan &> /dev/null; then alias rscan='rustscan'; fi
+if command -v rustscan &> /dev/null; then alias scan='rustscan'; fi
 if command -v diskonaut &> /dev/null; then alias disk-vis='diskonaut'; fi
 EOT
 fi
@@ -725,8 +731,8 @@ if command -v ugrep &> /dev/null; then alias ug='ugrep'; fi
 if command -v termscp &> /dev/null; then alias scp-ui='termscp'; fi
 if command -v lychee &> /dev/null; then alias links='lychee'; fi
 if command -v bluetuith &> /dev/null; then alias bt-ui='bluetuith'; fi
-if command -v czg &> /dev/null; then alias cz='czg'; fi
-if command -v batman &> /dev/null; then alias manb='batman'; fi
+if command -v czg &> /dev/null; then alias c='czg'; fi
+if command -v batman &> /dev/null; then alias man='batman'; fi
 EOT
 fi
 
@@ -776,6 +782,19 @@ if command -v gitingest &> /dev/null; then alias ingest='gitingest'; fi
 if command -v harlequin &> /dev/null; then alias sql-ide='harlequin'; fi
 if command -v slumber &> /dev/null; then alias http-ui='slumber'; fi
 if command -v plandex &> /dev/null; then alias plandex-ai='plandex'; fi
+EOT
+fi
+
+# Check if Experimental 2026 Apps are present in .zshrc
+if ! grep -q "# --- Experimental 2026 Apps ---" "$ZSHRC"; then
+    echo -e "${c}Appending Experimental 2026 Apps to .zshrc...${r}"
+    cat <<EOT >> $ZSHRC
+
+# --- Experimental 2026 Apps ---
+if command -v dotenvx &> /dev/null; then alias envx='dotenvx'; fi
+if command -v zrok &> /dev/null; then alias tunnel-alt='zrok'; fi
+if command -v git-sim &> /dev/null; then alias gsim='git-sim'; fi
+if command -v charm &> /dev/null; then alias charm-tools='charm'; fi
 EOT
 fi
 

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -54,6 +54,9 @@ run_step() {
   "$@"
 }
 
+SUCCESS_COUNT=0
+FAIL_COUNT=0
+
 run_module() {
   local module="$1"
   local current_idx="$2"
@@ -68,15 +71,22 @@ run_module() {
 
   if [[ "$DRY_RUN" == true ]]; then
     run_step "$progress_prefix Executando módulo: $module" "$script"
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
   else
     if command -v "$GUM" &> /dev/null; then
       if "$GUM" spin --spinner globe --spinner.foreground "#ff7edb" --title "$($GUM style --foreground "#72f1b8" "$progress_prefix Executando módulo: $module...")" -- bash -c '"$1" > "/tmp/setup-2026-$2.log" 2>&1' -- "$script" "$module"; then
         echo "$($GUM style --foreground "#72f1b8" "✔") $($GUM style --foreground "#f8f8f2" "$progress_prefix Módulo") $($GUM style --foreground "#fede5d" "$module") $($GUM style --foreground "#f8f8f2" "instalado com sucesso!")"
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
       else
         echo "$($GUM style --foreground "#ff7edb" "✖") $($GUM style --foreground "#f8f8f2" "$progress_prefix Erro ao instalar módulo") $($GUM style --foreground "#fede5d" "$module")$($GUM style --foreground "#f8f8f2" ". Verifique os logs.")"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
       fi
     else
-      run_step "$progress_prefix Executando módulo: $module" "$script"
+      if run_step "$progress_prefix Executando módulo: $module" "$script"; then
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+      else
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+      fi
     fi
   fi
 }
@@ -291,6 +301,14 @@ fi
 
 if [[ "$DRY_RUN" == false ]]; then
   if command -v "$GUM" &> /dev/null; then
+    SUMMARY_BOX=$("$GUM" style \
+      --foreground "#f8f8f2" --border-foreground "#72f1b8" --border double \
+      --align left --width 60 --margin "1 2" --padding "1 2" \
+      "📋 $($GUM style --foreground "#fede5d" "Resumo da Instalação")" \
+      "" \
+      "Perfil: $($GUM style --foreground "#36f9f6" "$PROFILE")" \
+      "Total de Módulos: $($GUM style --foreground "#ff7edb" "${#MODULES[@]}")")
+    echo "$SUMMARY_BOX"
     echo ""
     if ! "$GUM" confirm \
       --prompt.foreground "#ff7edb" \
@@ -304,6 +322,9 @@ if [[ "$DRY_RUN" == false ]]; then
     fi
     echo ""
   else
+    echo "Resumo da Instalação:"
+    echo "Perfil: $PROFILE"
+    echo "Total de Módulos: ${#MODULES[@]}"
     read -rp "Deseja prosseguir com a instalação destes módulos? (S/n): " confirm
     if [[ "$confirm" =~ ^[Nn] ]]; then
       log "Instalação cancelada pelo usuário."
@@ -352,7 +373,10 @@ if command -v "$GUM" &> /dev/null; then
       "🚀 $($GUM style --foreground "#36f9f6" "TRANSMISSÃO CONCLUÍDA!") 🛸" \
       "Perfil $($GUM style --foreground "#282a36" --background "#72f1b8" " $PROFILE ") ativado com sucesso!" \
       "Tempo total de salto: $($GUM style --foreground "#fede5d" "${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s")" \
-    "" \
+      "" \
+      "Módulos com sucesso: $($GUM style --foreground "#72f1b8" "$SUCCESS_COUNT")" \
+      "Módulos com falha: $($GUM style --foreground "#ff7edb" "$FAIL_COUNT")" \
+      "" \
     "A matrix foi atualizada e está pronta para uso." \
     "Feche este terminal e abra um novo para carregar sua nova realidade." \
     "" \
@@ -360,6 +384,7 @@ if command -v "$GUM" &> /dev/null; then
   echo "$("$GUM" join --align center "$ART_BOX" "$TEXT_BOX")"
 else
   log "Finalizado com sucesso em ${ELAPSED_MINUTES}m ${ELAPSED_SECONDS}s. Reinicie seu terminal."
+  log "Sucesso: $SUCCESS_COUNT | Falha: $FAIL_COUNT"
   log "Logs de instalação disponíveis em: /tmp/setup-2026-*.log"
 fi
 


### PR DESCRIPTION
This PR addresses the user's request to improve the installation interface and add new "useful 2026 apps". 

Changes include:
1. Enhancing `setup-2026.sh` to track success/failure module counts and displaying a pre-installation configuration summary.
2. Appending 4 new modern experimental CLI apps (`dotenvx`, `zrok`, `git-sim`, `charm`) to `programas/cli-tools/setup.sh`.
3. Updating the zsh configuration (`programas/zsh/setup.sh`) with corresponding aliases for the new apps, alongside fixing a few pre-existing alias mismatches (`scan`, `c`, `man`).

---
*PR created automatically by Jules for task [8255359677711120989](https://jules.google.com/task/8255359677711120989) started by @juninmd*