### PR TITLE
feat: add new 2026 apps and enhance installer UI

### DIFF
--- a/programas/brave/setup.sh
+++ b/programas/brave/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Brave Browser...${r}"
+sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+sudo apt update
+sudo apt install -y brave-browser
+echo -e "${c}Brave Browser installed!${r}"

--- a/programas/discord/setup.sh
+++ b/programas/discord/setup.sh
@@ -3,6 +3,6 @@ c='\e[32m'
 r='\e[0m'
 echo -e "${c}Installing Discord...${r}"
 wget -O discord.deb "https://discordapp.com/api/download?platform=linux&format=deb"
-sudo dpkg -i discord.deb || sudo apt-get install -f -y
+sudo apt install -y ./discord.deb
 rm discord.deb
 echo -e "${c}Discord installed!${r}"

--- a/programas/discord/setup.sh
+++ b/programas/discord/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Discord...${r}"
+wget -O discord.deb "https://discordapp.com/api/download?platform=linux&format=deb"
+sudo dpkg -i discord.deb || sudo apt-get install -f -y
+rm discord.deb
+echo -e "${c}Discord installed!${r}"

--- a/programas/docker/setup.sh
+++ b/programas/docker/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Docker Engine...${r}"
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo usermod -aG docker $USER
+echo -e "${c}Docker Engine installed! Please log out and back in for group changes to take effect.${r}"

--- a/programas/ghostty/setup.sh
+++ b/programas/ghostty/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Ghostty...${r}"
+# Assuming Debian/Ubuntu, it is distributed via deb or apt, but building from source or using snap is common.
+# Ghostty requires adding a specific PPA on Ubuntu.
+sudo add-apt-repository -y ppa:ramonpoca/ghostty
+sudo apt-get update
+sudo apt-get install -y ghostty
+echo -e "${c}Ghostty installed!${r}"

--- a/programas/neovim/setup.sh
+++ b/programas/neovim/setup.sh
@@ -3,7 +3,7 @@ c='\e[32m'
 r='\e[0m'
 echo -e "${c}Installing Neovim...${r}"
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
-sudo rm -rf /opt/nvim
+sudo rm -rf /opt/nvim-linux64
 sudo tar -C /opt -xzf nvim-linux64.tar.gz
 sudo ln -sf /opt/nvim-linux64/bin/nvim /usr/local/bin/nvim
 rm nvim-linux64.tar.gz

--- a/programas/neovim/setup.sh
+++ b/programas/neovim/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Neovim...${r}"
+curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
+sudo rm -rf /opt/nvim
+sudo tar -C /opt -xzf nvim-linux64.tar.gz
+sudo ln -sf /opt/nvim-linux64/bin/nvim /usr/local/bin/nvim
+rm nvim-linux64.tar.gz
+echo -e "${c}Neovim installed!${r}"

--- a/programas/obsidian/setup.sh
+++ b/programas/obsidian/setup.sh
@@ -2,11 +2,11 @@
 c='\e[32m'
 r='\e[0m'
 echo -e "${c}Installing Obsidian...${r}"
-LATEST_RELEASE=$(curl -s https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest | grep "browser_download_url.*_amd64.deb" | cut -d '"' -f 4)
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest | grep -o 'https://[^" ]*_amd64.deb' | head -n 1)
 if [ -z "$LATEST_RELEASE" ]; then
     LATEST_RELEASE="https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.12/obsidian_1.5.12_amd64.deb"
 fi
 wget -qO obsidian.deb "$LATEST_RELEASE"
-sudo dpkg -i obsidian.deb || sudo apt-get install -f -y
+sudo apt install -y ./obsidian.deb
 rm obsidian.deb
 echo -e "${c}Obsidian installed!${r}"

--- a/programas/obsidian/setup.sh
+++ b/programas/obsidian/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+c='\e[32m'
+r='\e[0m'
+echo -e "${c}Installing Obsidian...${r}"
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest | grep "browser_download_url.*_amd64.deb" | cut -d '"' -f 4)
+if [ -z "$LATEST_RELEASE" ]; then
+    LATEST_RELEASE="https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.12/obsidian_1.5.12_amd64.deb"
+fi
+wget -qO obsidian.deb "$LATEST_RELEASE"
+sudo dpkg -i obsidian.deb || sudo apt-get install -f -y
+rm obsidian.deb
+echo -e "${c}Obsidian installed!${r}"

--- a/setup-2026.sh
+++ b/setup-2026.sh
@@ -162,15 +162,15 @@ if [[ -z "$PROFILE" ]]; then
     echo ""
 
     "$GUM" style \
-      --foreground "#fede5d" \
-      --border rounded --border-foreground "#ff7edb" \
+      --foreground "#fede5d" --bold \
+      --border double --border-foreground "#ff7edb" \
       --padding "1 2" --margin "1 0" --align center --width 100 \
       "🌐 Iniciando Protocolo de Setup 2026 🌐" \
       "Selecione o perfil de instalação para turbinar sua máquina:"
     echo ""
     PROFILE_CHOICE=$("$GUM" choose \
       --height=20 \
-      --cursor="🚀 " \
+      --cursor="🛸 " \
       --header="Escolha o seu nível de poder:" \
       --header.foreground="#ff7edb" \
       --cursor.foreground="#72f1b8" \
@@ -192,13 +192,13 @@ case "$PROFILE" in
     DEFAULT_MODULES=(cli-tools zsh starship vscode)
     ;;
   dev)
-    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi)
+    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi neovim docker)
     ;;
   full)
-    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi firefox slack android)
+    DEFAULT_MODULES=(cli-tools zsh starship bun mysql lazygit lazydocker vscode zellij yazi firefox slack android neovim docker brave discord ghostty obsidian)
     ;;
   ai-dev)
-    DEFAULT_MODULES=(cli-tools zsh starship bun cursor zed warp lazygit lazydocker zellij yazi)
+    DEFAULT_MODULES=(cli-tools zsh starship bun cursor zed warp lazygit lazydocker zellij yazi neovim docker)
     ;;
   *)
     log "Perfil inválido: $PROFILE"
@@ -211,6 +211,12 @@ log "Perfil selecionado: $PROFILE"
 
 # Human-readable descriptions for the modules
 declare -A MOD_DESC=(
+  ["ghostty"]="👻 Ghostty (Emulador de Terminal Ultrarrápido)"
+  ["obsidian"]="📓 Obsidian (Second Brain & Notas)"
+  ["neovim"]="📝 Neovim (Editor de texto avançado)"
+  ["brave"]="🦁 Brave (Navegador focado em privacidade)"
+  ["discord"]="🎮 Discord (Comunicação de voz e texto)"
+  ["docker"]="🐳 Docker Engine (Contêineres)"
   ["android"]="📱 Android Studio & SDK (Plataforma Mobile)"
   ["bun"]="🥟 Bun JavaScript runtime (Ultrarrápido)"
   ["cli-tools"]="🧰 O Arsenal Definitivo 2026 (Ferramentas CLI)"
@@ -242,8 +248,8 @@ done
 if command -v "$GUM" &> /dev/null; then
   echo ""
   "$GUM" style \
-    --foreground "#fede5d" \
-    --border rounded --border-foreground "#ff7edb" \
+    --foreground "#fede5d" --bold \
+    --border double --border-foreground "#ff7edb" \
     --padding "1 2" --margin "1 0" --align center --width 80 \
     "Selecione os módulos que deseja instalar:" \
     "(Use Espaço para marcar/desmarcar, Enter para confirmar)"
@@ -265,7 +271,7 @@ if command -v "$GUM" &> /dev/null; then
   DEFAULTS=$(IFS=,; echo "${DEFAULTS_DESC[*]}")
 
   # Interactive selection
-  SELECTED_TEXT=$("$GUM" choose --no-limit --cursor="👉 " \
+  SELECTED_TEXT=$("$GUM" choose --no-limit --cursor="✨ " \
     --height=20 \
     --selected="${DEFAULTS}" \
     --selected.foreground="#36f9f6" \
@@ -291,7 +297,7 @@ if command -v "$GUM" &> /dev/null; then
       MOD_LIST+="  $($GUM style --foreground "#ff7edb" "•") $($GUM style --foreground "#fede5d" "$mod") $($GUM style --foreground "#6272a4" "($desc)")"$'\n'
     fi
   done
-  echo -e "$MOD_LIST" | "$GUM" style --border rounded --margin "0 2" --padding "1 2" --border-foreground "#ff7edb"
+  echo -e "$MOD_LIST" | "$GUM" style --border double --margin "0 2" --padding "1 2" --border-foreground "#ff7edb"
   echo ""
 else
   MODULES=("${DEFAULT_MODULES[@]}")


### PR DESCRIPTION
Adds standalone installation scripts for new modern apps (Ghostty, Obsidian, Neovim, Brave, Discord, Docker) and integrates them into the `setup-2026.sh` installer profiles. Also enhances the UI styling with double borders and new cursor emojis to match the Synthwave aesthetic.

---
*PR created automatically by Jules for task [9933286858934090695](https://jules.google.com/task/9933286858934090695) started by @juninmd*